### PR TITLE
Changed HMACs to be extensible/replaceable

### DIFF
--- a/sources/MVCFramework.HMAC.pas
+++ b/sources/MVCFramework.HMAC.pas
@@ -2,7 +2,7 @@
 //
 // Delphi MVC Framework
 //
-// Copyright (c) 2010-2017 Daniele Teti and the DMVCFramework Team
+// Copyright (c) 2010-2016 Daniele Teti and the DMVCFramework Team
 //
 // https://github.com/danieleteti/delphimvcframework
 //
@@ -36,42 +36,52 @@ type
 
   end;
 
-  THMACClass = class of TIdHMAC;
+  IHMAC = interface
+    ['{95134024-BBAF-4E52-A4C3-54189672E18A}']
+    function HashValue(const Input, key: String): TBytes;
+  end;
+
 
 function HMAC(const Algorithm: String; const Input, Key: string): TBytes;
-procedure RegisterHMACAlgorithm(const Algorithm: String; Clazz: THMACClass);
+procedure RegisterHMACAlgorithm(const Algorithm: String; Impl: IHMAC);
 procedure UnRegisterHMACAlgorithm(const Algorithm: String);
 
 implementation
 
 uses
+
   IdSSLOpenSSL, IdHash, IdGlobal, IdHMACMD5,
   IdHMACSHA1, System.Generics.Collections;
 
 var
-  GHMACRegistry: TDictionary<string, THMACClass>;
+  GHMACRegistry: TDictionary<string, IHMAC>;
+
+type
+  THMACClass = class of TIdHMAC;
+
+  TIdHMACWrapper = class(TInterfacedObject, IHMAC)
+  private
+    FClass: THMACClass;
+  public
+    constructor Create(IdClass: THMACClass);
+    function HashValue(const Input: string;
+      const key: string): System.TArray<System.Byte>;
+
+  end;
 
 function HMAC(const Algorithm: String; const Input, Key: string): TBytes;
-var
-  lHMAC: TIdHMAC;
 begin
   if not GHMACRegistry.ContainsKey(Algorithm) then
     raise EMVCHMACException.CreateFmt('Unknown HMAC algorithm [%s]', [Algorithm]);
 
-  lHMAC := GHMACRegistry[Algorithm].Create;
-  try
-    lHMAC.Key := ToBytes(Key);
-    Result := TBytes(lHMAC.HashValue(ToBytes(Input)));
-  finally
-    lHMAC.Free;
-  end;
+  result := GHMACRegistry[Algorithm].HashValue(Input, Key);
 end;
 
-procedure RegisterHMACAlgorithm(const Algorithm: String; Clazz: THMACClass);
+procedure RegisterHMACAlgorithm(const Algorithm: String; Impl: IHMAC);
 begin
   if GHMACRegistry.ContainsKey(Algorithm) then
     raise EMVCHMACException.Create('Algorithm already registered');
-  GHMACRegistry.Add(Algorithm, Clazz);
+  GHMACRegistry.Add(Algorithm, Impl);
 end;
 
 procedure UnRegisterHMACAlgorithm(const Algorithm: String);
@@ -79,25 +89,49 @@ begin
   GHMACRegistry.Remove(Algorithm);
 end;
 
+
+
+{ TIdHMACWrapper }
+
+constructor TIdHMACWrapper.Create(IdClass: THMACClass);
+begin
+  FClass := IdClass;
+end;
+
+function TIdHMACWrapper.HashValue(const Input,
+  key: string): System.TArray<System.Byte>;
+var
+  lHMAC: TIdHMAC;
+begin
+  Assert(IdSSLOpenSSL.LoadOpenSSLLibrary, 'HMAC requires OpenSSL libraries');
+  lHMAC := FClass.Create;
+  try
+    lHMAC.Key := ToBytes(Key, IndyTextEncoding_UTF8);
+    Result := TBytes(lHMAC.HashValue(ToBytes(Input, IndyTextEncoding_UTF8)));
+  finally
+    lHMAC.Free;
+  end;
+end;
+
 initialization
 
-Assert(IdSSLOpenSSL.LoadOpenSSLLibrary, 'HMAC requires OpenSSL libraries');
 
-GHMACRegistry := TDictionary<string, THMACClass>.Create;
+
+GHMACRegistry := TDictionary<string, IHMAC>.Create;
 
 //registering based on hash function
-RegisterHMACAlgorithm('md5', TIdHMACMD5);
-RegisterHMACAlgorithm('sha1', TIdHMACSHA1);
-RegisterHMACAlgorithm('sha224', TIdHMACSHA224);
-RegisterHMACAlgorithm('sha256', TIdHMACSHA256);
-RegisterHMACAlgorithm('sha384', TIdHMACSHA384);
-RegisterHMACAlgorithm('sha512', TIdHMACSHA512);
+RegisterHMACAlgorithm('md5', TIdHMACWrapper.create(TIdHMACMD5));
+RegisterHMACAlgorithm('sha1', TIdHMACWrapper.create(TIdHMACSHA1));
+RegisterHMACAlgorithm('sha224', TIdHMACWrapper.create(TIdHMACSHA224));
+RegisterHMACAlgorithm('sha256', TIdHMACWrapper.create(TIdHMACSHA256));
+RegisterHMACAlgorithm('sha384', TIdHMACWrapper.create(TIdHMACSHA384));
+RegisterHMACAlgorithm('sha512', TIdHMACWrapper.create(TIdHMACSHA512));
 
 
 //the same using the JWT naming
-RegisterHMACAlgorithm('HS256', TIdHMACSHA256);
-RegisterHMACAlgorithm('HS384', TIdHMACSHA384);
-RegisterHMACAlgorithm('HS512', TIdHMACSHA512);
+RegisterHMACAlgorithm('HS256', TIdHMACWrapper.create(TIdHMACSHA256));
+RegisterHMACAlgorithm('HS384', TIdHMACWrapper.create(TIdHMACSHA384));
+RegisterHMACAlgorithm('HS512', TIdHMACWrapper.create(TIdHMACSHA512));
 
 finalization
 


### PR DESCRIPTION
Used an interface for HMAC registration instead of hard-coding against Indy classes. Wrote a wrapper for Indy HMAC classes (interfaced class factory). This should allow for easy extension/replacement of HMAC implementations.
In addition, when using the Indy classes, the encoding used for computing the hash is now forced to UTF8 instead of using the Indy default encoding (ASCII)