### PR TITLE
Fixed JWT encoding

### DIFF
--- a/sources/MVCFramework.Commons.pas
+++ b/sources/MVCFramework.Commons.pas
@@ -2,7 +2,7 @@
 //
 // Delphi MVC Framework
 //
-// Copyright (c) 2010-2016 Daniele Teti and the DMVCFramework Team
+// Copyright (c) 2010-2017 Daniele Teti and the DMVCFramework Team
 //
 // https://github.com/danieleteti/delphimvcframework
 //
@@ -26,16 +26,23 @@ unit MVCFramework.Commons;
 
 interface
 
+{$I dmvcframework.inc}
+
 uses
-  System.SysUtils
-{$IF CompilerVersion < 27 }
-    , Data.DBXJSON
-{$ELSE}
+  System.SysUtils, Generics.Collections
+{$IFDEF SYSTEMJSON} // XE6
     , System.JSON
+{$ELSE}
+    , Data.DBXJSON
 {$ENDIF}
     , System.Generics.Collections, MVCFramework.Session, LoggerPro;
 
+{$I dmvcframeworkbuildconsts.inc}
+
 type
+  TMVCHTTPMethodType = (httpGET, httpPOST, httpPUT, httpDELETE, httpHEAD,
+    httpOPTIONS, httpPATCH, httpTRACE);
+  TMVCHTTPMethods = set of TMVCHTTPMethodType;
 
   TMVCMimeType = class sealed
   public const

--- a/sources/MVCFramework.Commons.pas
+++ b/sources/MVCFramework.Commons.pas
@@ -602,7 +602,7 @@ var
   Strlen: Integer;
 begin
   Strlen := Length(Value);
-  while Value[Strlen]=TrimmedChar do
+  while (Strlen>0) and (Value[Strlen]=TrimmedChar) do
     dec(StrLen);
   result := copy(value, 1, StrLen)
 end;

--- a/sources/MVCFramework.Commons.pas
+++ b/sources/MVCFramework.Commons.pas
@@ -2,7 +2,7 @@
 //
 // Delphi MVC Framework
 //
-// Copyright (c) 2010-2017 Daniele Teti and the DMVCFramework Team
+// Copyright (c) 2010-2016 Daniele Teti and the DMVCFramework Team
 //
 // https://github.com/danieleteti/delphimvcframework
 //
@@ -26,23 +26,16 @@ unit MVCFramework.Commons;
 
 interface
 
-{$I dmvcframework.inc}
-
 uses
-  System.SysUtils, Generics.Collections
-{$IFDEF SYSTEMJSON} // XE6
-    , System.JSON
-{$ELSE}
+  System.SysUtils
+{$IF CompilerVersion < 27 }
     , Data.DBXJSON
+{$ELSE}
+    , System.JSON
 {$ENDIF}
     , System.Generics.Collections, MVCFramework.Session, LoggerPro;
 
-{$I dmvcframeworkbuildconsts.inc}
-
 type
-  TMVCHTTPMethodType = (httpGET, httpPOST, httpPUT, httpDELETE, httpHEAD,
-    httpOPTIONS, httpPATCH, httpTRACE);
-  TMVCHTTPMethods = set of TMVCHTTPMethodType;
 
   TMVCMimeType = class sealed
   public const
@@ -350,6 +343,11 @@ function B64Encode(const Value: string): string; overload;
 function B64Encode(const Value: TBytes): string; overload;
 function B64Decode(const Value: string): string;
 
+function URLSafeB64encode(const Value: string; IncludePadding: Boolean): String;  overload;
+function URLSafeB64encode(const Value: TBytes; IncludePadding: Boolean): String;  overload;
+function URLSafeB64Decode(const Value: string): String;
+
+
 function ByteToHex(InByte: byte): string;
 function BytesToHex(Bytes: TBytes): string;
 
@@ -365,7 +363,8 @@ uses
   System.IOUtils,
   idGlobal,
   System.StrUtils,
-  idCoderMIME;
+  idCoderMIME,
+  IdCoder3to4;
 
 const
   ReservedIPs: array [1 .. 11] of array [1 .. 2] of string =
@@ -542,6 +541,91 @@ begin
   FDetailedMessage := Value;
 end;
 
+type
+  TURLSafeEncode = class(TIdEncoder3to4)
+  protected
+    procedure InitComponent; override;
+  public
+
+  end;
+  TURLSafeDecode = class(TIdDecoder4to3)
+  protected
+    class var GSafeBaseBase64DecodeTable: TIdDecodeTable;
+    procedure InitComponent; override;
+  public
+
+  end;
+
+const
+  GURLSafeBase64CodeTable: string =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';    {Do not Localize}
+
+
+procedure TURLSafeEncode.InitComponent;
+begin
+  inherited;
+  FCodingTable := ToBytes(GURLSafeBase64CodeTable);
+  FFillChar := '=';  {Do not Localize}
+end;
+
+procedure TURLSafeDecode.InitComponent;
+begin
+  inherited;
+  FDecodeTable := GSafeBaseBase64DecodeTable;
+  FCodingTable := ToBytes(GURLSafeBase64CodeTable);
+  FFillChar := '=';  {Do not Localize}
+end;
+
+function URLSafeB64encode(const Value: string; IncludePadding: Boolean): String; overload;
+begin
+  if IncludePadding then
+    Result := TURLSafeEncode.EncodeString(Value)
+  else
+    Result := TURLSafeEncode.EncodeString(Value).Replace('=', '', [rfReplaceAll]);
+end;
+
+/// <summary>
+///   Remove "trimmed" character from the end of the string passed as parameter
+/// </summary>
+/// <param name="Value">Original string</param>
+/// <param name="TrimmedChar">Character to remove</param>
+/// <returns>Resulting string</returns>
+function RTrim(const Value: string; TrimmedChar: char): string;
+var
+  Strlen: Integer;
+begin
+  Strlen := Length(Value);
+  while Value[Strlen]=TrimmedChar do
+    dec(StrLen);
+  result := copy(value, 1, StrLen)
+end;
+
+function URLSafeB64encode(const Value: TBytes; IncludePadding: Boolean): String;  overload;
+begin
+
+  if IncludePadding then
+    Result := TURLSafeEncode.EncodeBytes(TIdBytes(Value))
+  else
+    Result := RTrim(TURLSafeEncode.EncodeBytes(TIdBytes(Value)), '=');
+end;
+
+function URLSafeB64Decode(const Value: string): String;
+begin
+  // SGR 2017-07-03 : b64url might not include padding. Need to add it before decoding
+  case Length(value) mod 4 of
+    0:
+    begin
+      Result := TURLSafeDecode.DecodeString(Value);
+    end;
+    2:
+      Result := TURLSafeDecode.DecodeString(Value + '==');
+    3:
+      Result := TURLSafeDecode.DecodeString(Value + '=');
+  else
+    raise EExternalException.Create('Illegal base64url length');
+  end;
+end;
+
 function B64Encode(const Value: string): string;
 overload
 // var
@@ -618,6 +702,8 @@ end;
 initialization
 
 Lock := TObject.Create;
+// SGR 2017-07-03 : Initialize decoding table for URLSafe Gb64 encoding
+TURLSafeDecode.ConstructDecodeTable(GURLSafeBase64CodeTable, TURLSafeDecode.GSafeBaseBase64DecodeTable);
 
 gAppExe := ExtractFileName(GetModuleName(HInstance) { ParamStr(0) } );
 gAppName := ChangeFileExt(gAppExe, '');

--- a/sources/MVCFramework.JWT.pas
+++ b/sources/MVCFramework.JWT.pas
@@ -605,9 +605,9 @@ begin
     raise EMVCJWTException.Create(lError);
 
   lPieces := Token.Split(['.']);
-  lJHeader := TJSONObject.ParseJSONValue(B64Decode(lPieces[0])) as TJSONObject;
+  lJHeader := TJSONObject.ParseJSONValue(URLSafeB64Decode(lPieces[0])) as TJSONObject;
   try
-    lJPayload := TJSONObject.ParseJSONValue(B64Decode(lPieces[1])) as TJSONObject;
+    lJPayload := TJSONObject.ParseJSONValue(URLSafeB64Decode(lPieces[1])) as TJSONObject;
     try
       // loading data from token into self
       FHMACAlgorithm := lJHeader.Values['alg'].Value;


### PR DESCRIPTION
JWT should use base64url encoding with no padding instead of base64 encoding. Without this change, interoperability with other implementation is not possible.
Warning: this is a BREAKING CHANGE. existing tokens will not work any more.