### PR TITLE
Add string enumerator parser

### DIFF
--- a/sources/MVCFramework.Serializer.JsonDataObjects.pas
+++ b/sources/MVCFramework.Serializer.JsonDataObjects.pas
@@ -6,7 +6,7 @@
 //
 // https://github.com/danieleteti/delphimvcframework
 //
-// Collaborators with this file: Ezequiel Juliano Müller (ezequieljuliano@gmail.com)
+// Collaborators with this file: Ezequiel Juliano MÃ¼ller (ezequieljuliano@gmail.com)
 //
 // ***************************************************************************
 //
@@ -606,6 +606,9 @@ begin
         else if (AValue.TypeInfo = System.TypeInfo(TTime)) then
           AValue := TValue.From<TTime>(ISOTimeToTime(AJsonObject[AName].Value))
 
+        else if (AValue.Kind = tkEnumeration) then
+          TValue.Make(GetEnumValue(AValue.TypeInfo, AJsonObject[AName].Value), AValue.TypeInfo, AValue)
+          
         else
           AValue := TValue.From<string>(AJsonObject[AName].Value);
       end;


### PR DESCRIPTION
If a enum name is equal to json value, parse it to enum.

Ex.: 
Enum: 
`TColor = (RED, BLUE, BLACK);`

JSON: 
`{"color": "BLUE"}`

Class:
```delphi
TFoo = class
  property color: TColor;
end;
```