### PR TITLE
Fix import to run in Delphi Starter Edition

### DIFF
--- a/sources/ObjectsMappers.pas
+++ b/sources/ObjectsMappers.pas
@@ -32,10 +32,10 @@ interface
 uses
   System.RTTI,
   System.IOUtils,
-  DBXPLatform,
   DB,
   Generics.Collections,
 {$IFDEF USEDBX}
+  DBXPLatform,
   Data.SqlExpr,
   DBXCommon,
 {$IFEND}


### PR DESCRIPTION
Including the DBX* unit within the {$IFDEF USEDBX} to run Delphi Starter Edition
Regards.
