### PR TITLE
Updated MVCFramework.HMAC.pas to use new Delphi HMAC classes

### DIFF
--- a/sources/MVCFramework.HMAC.pas
+++ b/sources/MVCFramework.HMAC.pas
@@ -63,7 +63,7 @@ implementation
 
 uses
 
-  IdSSLOpenSSL, IdHash, IdGlobal, IdHMACMD5, System.Hash,
+  IdSSLOpenSSL, IdHash, IdGlobal, IdHMACMD5, {$IFDEF VER320} System.Hash,{$ENDIF}
   IdHMACSHA1, System.Generics.Collections;
 
 var
@@ -189,7 +189,7 @@ RegisterHMACAlgorithm('HS256', TSHA2HMACWrapper.create(THashSHA2.TSHA2Version.SH
 RegisterHMACAlgorithm('HS384', TSHA2HMACWrapper.create(THashSHA2.TSHA2Version.SHA384));
 RegisterHMACAlgorithm('HS512', TSHA2HMACWrapper.create(THashSHA2.TSHA2Version.SHA512));
 
-{$else}
+{$ELSE}
 RegisterHMACAlgorithm('md5', TIdHMACWrapper.create(TIdHMACMD5));
 RegisterHMACAlgorithm('sha1', TIdHMACWrapper.create(TIdHMACSHA1));
 RegisterHMACAlgorithm('sha224', TIdHMACWrapper.create(TIdHMACSHA224));
@@ -201,7 +201,7 @@ RegisterHMACAlgorithm('sha512', TIdHMACWrapper.create(TIdHMACSHA512));
 RegisterHMACAlgorithm('HS256', TIdHMACWrapper.create(TIdHMACSHA256));
 RegisterHMACAlgorithm('HS384', TIdHMACWrapper.create(TIdHMACSHA384));
 RegisterHMACAlgorithm('HS512', TIdHMACWrapper.create(TIdHMACSHA512));
-{$endif}
+{$ENDIF}
 
 finalization
 


### PR DESCRIPTION
I was looking to use the MVCFramework.JWT class on android and found that one of the problems was that it used indy/openssl functions for HMAC.  Recent versions of Delphi now include these functions in the box - without using indy, so I have made it so that these functions are used for Seattle and later versions of delphi.