### PR TITLE
Bug fix when deserialize object with custom type and JSON with null value

### DIFF
--- a/sources/MVCFramework.Serializer.JsonDataObjects.pas
+++ b/sources/MVCFramework.Serializer.JsonDataObjects.pas
@@ -531,8 +531,12 @@ begin
       jdtNone:
         Exit;
       jdtObject:
-        GetTypeSerializers.Items[AValue.TypeInfo].DeserializeAttribute(AValue, AName, AJsonObject[AName].ObjectValue,
-          ACustomAttributes);
+        begin
+          /// <summary>JsonDataObjects assumes values null as jdtObject</summary>
+          if AJsonObject[AName].ObjectValue <> nil then
+            GetTypeSerializers.Items[AValue.TypeInfo].DeserializeAttribute(AValue, AName, AJsonObject[AName].ObjectValue,
+              ACustomAttributes);
+        end;
       jdtArray:
         GetTypeSerializers.Items[AValue.TypeInfo].DeserializeAttribute(AValue, AName, AJsonObject[AName].ArrayValue,
           ACustomAttributes);


### PR DESCRIPTION
Access violation was caused when deserializing an object with a custom data type.
The error can be seen in samples\renders_spring4d_nullables
POST api/people