### PR TITLE
Change into class helper TMVCStreamHelper to suporte VCL and FMX strings

### DIFF
--- a/sources/MVCFramework.Commons.pas
+++ b/sources/MVCFramework.Commons.pas
@@ -980,7 +980,7 @@ var
   UFTStr: UTF8String;
 begin
   UFTStr := UTF8String(AString);
-  Self.WriteBuffer(UFTStr[1], Length(UFTStr));
+  Self.WriteBuffer(UFTStr[Low(UFTStr)], Length(UFTStr));
 end;
 
 initialization


### PR DESCRIPTION
Fix to correctly support 1-based and 0-based strings in both VCL and FMX