### PR TITLE
RQL Changes

### DIFF
--- a/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
+++ b/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
@@ -117,6 +117,10 @@ begin
       begin
         Result := Format('(%s containing ''%s'')', [lDBFieldName, lValue.DeQuotedString.ToLower ])
       end;
+    tkIn:
+      begin
+        Result := Format('(%s IN (%s))', [lDBFieldName, lValue])
+      end;
   end;
 end;
 

--- a/sources/MVCFramework.RQL.AST2MSSQL.pas
+++ b/sources/MVCFramework.RQL.AST2MSSQL.pas
@@ -124,6 +124,10 @@ begin
       begin
         Result := Format('(LOWER(%s) LIKE ''%%%s%%'')', [lDBFieldName, lValue.DeQuotedString.ToLower ])
       end;
+    tkIn:
+      begin
+        Result := Format('(%s IN (%s))', [lDBFieldName, lValue])
+      end;
   end;
 end;
 

--- a/sources/MVCFramework.RQL.AST2MySQL.pas
+++ b/sources/MVCFramework.RQL.AST2MySQL.pas
@@ -116,6 +116,10 @@ begin
       begin
         Result := Format('(LOWER(%s) LIKE ''%%%s%%'')', [lDBFieldName, lValue.DeQuotedString.ToLower ])
       end;
+    tkIn:
+      begin
+        Result := Format('(%s IN (%s))', [lDBFieldName, lValue])
+      end;
   end;
 end;
 

--- a/sources/MVCFramework.RQL.AST2PostgreSQL.pas
+++ b/sources/MVCFramework.RQL.AST2PostgreSQL.pas
@@ -116,6 +116,10 @@ begin
       begin
         Result := Format('(%s ILIKE ''%%%s%%'')', [lDBFieldName, lValue.DeQuotedString.ToLower ])
       end;
+    tkIn:
+      begin
+        Result := Format('(%s IN (%s))', [lDBFieldName, lValue])
+      end;
   end;
 end;
 

--- a/sources/MVCFramework.RQL.Parser.pas
+++ b/sources/MVCFramework.RQL.Parser.pas
@@ -767,7 +767,6 @@ end;
 function TRQL2SQL.MatchFieldArrayValue(out lFieldValue: string): Boolean;
 var
   lChar: Char;
-  lToken: TRQLToken;
 begin
   Result := True;
   while True do

--- a/tools/bin/rqlhistory.txt
+++ b/tools/bin/rqlhistory.txt
@@ -1,3 +1,6 @@
+in(name,['joão','duarte'])
+and(eq(name,"João"),in(codperson,[1,2,3]))
+in(codperson,[1,2,3])
 eq(name,-1)
 contains(nome,"João")
 sort(+last_name);limit(0,1)


### PR DESCRIPTION
Added RQL Operator IN for RQL Parser.
Example: RQL in(codperson,[1,2,3,4]) results SQL WHERE (codperson IN (1,2,3,4))

Correction in MatchFieldStringValue to Generate Exception when finding end of string without closing quotes.
