### PR TITLE
Correction in TMVCCompressionMiddleware

### DIFF
--- a/sources/MVCFramework.Middleware.Compression.pas
+++ b/sources/MVCFramework.Middleware.Compression.pas
@@ -73,7 +73,7 @@ var
   lTmpItem: string;
 begin
   lContentStream := Context.Response.RawWebResponse.ContentStream;
-  if (lContentStream = nil) or (lContentStream.Size <= fCompressionThreshold) then
+  if (lContentStream = nil) or (lContentStream is TFileStream) or (lContentStream.Size <= fCompressionThreshold) then
     Exit;
 
   lAcceptEncoding := Context.Request.Headers['Accept-Encoding'];


### PR DESCRIPTION
Correction in TMVCCompressionMiddleware to not compress ResponseStream of type TFileStream.
Exception was thrown when compressing contentstream of type TFileStream.