### PR TITLE
No set param datatype on TFireDACUtils.ObjectToParameters method

### DIFF
--- a/sources/MVCFramework.FireDAC.Utils.pas
+++ b/sources/MVCFramework.FireDAC.Utils.pas
@@ -43,7 +43,7 @@ type
     class function ExecuteQueryNoResult(AQuery: TFDQuery;
       AObject: TObject): Int64;
     class procedure ExecuteQuery(AQuery: TFDQuery; AObject: TObject);
-    class procedure ObjectToParameters(AFDParams: TFDParams; AObject: TObject; AParamPrefix: string = '');
+    class procedure ObjectToParameters(AFDParams: TFDParams; AObject: TObject; AParamPrefix: string = ''; ASetParamTypes: Boolean = True);
   end;
 
 implementation
@@ -79,7 +79,7 @@ begin
 end;
 
 class procedure TFireDACUtils.ObjectToParameters(AFDParams: TFDParams;
-  AObject: TObject; AParamPrefix: string);
+  AObject: TObject; AParamPrefix: string; ASetParamTypes: Boolean);
 var
   I: Integer;
   pname: string;
@@ -154,7 +154,12 @@ begin
       if Map.TryGetValue(pname, f) then
       begin
         fv := f.GetValue(AObject);
-        AFDParams[I].DataType := KindToFieldType(fv.Kind, f);
+        // #001: Erro ao definir parametros
+        if ASetParamTypes then
+        begin
+          AFDParams[I].DataType := KindToFieldType(fv.Kind, f);
+        end;
+        // #001: FIM
         // DmitryG - 2014-03-28
         AFDParams[I].Value := fv.AsVariant;
       end


### PR DESCRIPTION
When the data type of the parameter is already set, especially in the "varchar" type, in SQL Server, it is set to tString, and the method understands it as a tUString. So I commented this line and I just set the value, but not the data type.