### PR TITLE
Allow Authorization header to be set without getting EIdHTTPUnsupport…

### DIFF
--- a/sources/MVCFramework.Server.Impl.pas
+++ b/sources/MVCFramework.Server.Impl.pas
@@ -65,6 +65,9 @@ type
   TMVCListener = class(TInterfacedObject, IMVCListener)
   private
     FBridge: TIdHTTPWebBrokerBridge;
+    procedure OnParseAuthentication(AContext: TIdContext; const AAuthType,
+      AAuthData: String; var VUsername, VPassword: String;
+      var VHandled: Boolean);
   protected
     function GetActive: Boolean;
 
@@ -200,6 +203,7 @@ begin
   FBridge := TIdHTTPWebBrokerBridge.Create(nil);
   FBridge.DefaultPort := AProperties.GetPort;
   FBridge.MaxConnections := AProperties.GetMaxConnections;
+  FBridge.OnParseAuthentication := OnParseAuthentication;
   FBridge.RegisterWebModuleClass(AProperties.GetWebModuleClass);
 end;
 
@@ -208,6 +212,11 @@ begin
   if Assigned(FBridge) then
     FBridge.Free;
   inherited Destroy;
+end;
+
+procedure TMVCListener.OnParseAuthentication(AContext: TIdContext; const AAuthType, AAuthData: String; var VUsername, VPassword: String; var VHandled: Boolean);
+begin
+  vhandled := True;
 end;
 
 function TMVCListener.GetActive: Boolean;


### PR DESCRIPTION
Allow Authorization header to be set without getting EIdHTTPUnsupportedAuthorisationScheme when using TMVCListener