### PR TITLE
JWT middleware improvements

### DIFF
--- a/samples/jsonwebtoken/JWTServer.dpr
+++ b/samples/jsonwebtoken/JWTServer.dpr
@@ -10,6 +10,7 @@ uses
   Web.WebReq,
   Web.WebBroker,
   IdHTTPWebBrokerBridge,
+  IdContext,
   WebModuleUnit1 in 'WebModuleUnit1.pas' {WebModule1: TWebModule} ,
   AppControllerU in 'AppControllerU.pas',
   MVCFramework.Middleware.JWT in '..\..\sources\MVCFramework.Middleware.JWT.pas',
@@ -17,6 +18,12 @@ uses
 
 {$R *.res}
 
+type
+  TWebBrokerBridgeAuthEvent = class
+  public
+    class procedure ServerParserAuthentication(AContext: TIdContext; const AAuthType, AAuthData: String; var VUsername,
+    VPassword: String; var VHandled: Boolean);
+  end;
 
 procedure RunServer(APort: Integer);
 var
@@ -25,6 +32,7 @@ begin
   Writeln(Format('Starting HTTP Server or port %d', [APort]));
   LServer := TIdHTTPWebBrokerBridge.Create(nil);
   try
+    LServer.OnParseAuthentication := TWebBrokerBridgeAuthEvent.ServerParserAuthentication;
     LServer.DefaultPort := APort;
     LServer.Active := True;
     Writeln('Press RETURN to stop the server');
@@ -33,6 +41,15 @@ begin
   finally
     LServer.Free;
   end;
+end;
+
+{ TWebBrokerBridgeAuthEvent }
+
+class procedure TWebBrokerBridgeAuthEvent.ServerParserAuthentication(AContext: TIdContext; const AAuthType, AAuthData: String;
+  var VUsername, VPassword: String; var VHandled: Boolean);
+begin
+  if SameText(AAuthType, 'bearer') then
+    VHandled := True;
 end;
 
 begin

--- a/samples/jsonwebtoken/WebModuleUnit1.pas
+++ b/samples/jsonwebtoken/WebModuleUnit1.pas
@@ -58,7 +58,12 @@ begin
     TAuthenticationSample.Create,
     lClaimsSetup,
     'mys3cr37',
-    '/login'
+    '/login',
+    [TJWTCheckableClaim.ExpirationTime, TJWTCheckableClaim.NotBefore, TJWTCheckableClaim.IssuedAt],
+    300,
+    'Authorization',
+    'username',
+    'password'
     ));
 end;
 

--- a/samples/jsonwebtoken/vclclient/MainClientFormU.dfm
+++ b/samples/jsonwebtoken/vclclient/MainClientFormU.dfm
@@ -48,7 +48,7 @@ object Form5: TForm5
     Font.Style = []
     ParentFont = False
     ReadOnly = True
-    TabOrder = 0
+    TabOrder = 1
   end
   object Memo2: TMemo
     Left = 0
@@ -63,7 +63,7 @@ object Form5: TForm5
     Font.Style = []
     ParentFont = False
     ReadOnly = True
-    TabOrder = 1
+    TabOrder = 2
   end
   object Panel1: TPanel
     Left = 0
@@ -71,7 +71,7 @@ object Form5: TForm5
     Width = 647
     Height = 49
     Align = alTop
-    TabOrder = 2
+    TabOrder = 0
     object btnGet: TButton
       AlignWithMargins = True
       Left = 171
@@ -80,8 +80,9 @@ object Form5: TForm5
       Height = 41
       Align = alLeft
       Caption = 'Get a protected resource'
-      TabOrder = 0
+      TabOrder = 1
       OnClick = btnGetClick
+      ExplicitTop = 2
     end
     object btnLOGIN: TButton
       AlignWithMargins = True
@@ -91,7 +92,7 @@ object Form5: TForm5
       Height = 41
       Align = alLeft
       Caption = 'Login'
-      TabOrder = 1
+      TabOrder = 0
       OnClick = btnLOGINClick
     end
   end

--- a/samples/jsonwebtoken/vclclient/MainClientFormU.pas
+++ b/samples/jsonwebtoken/vclclient/MainClientFormU.pas
@@ -49,9 +49,10 @@ begin
   { Getting JSON response }
   lClient := TRESTClient.Create('localhost', 8080);
   try
+    lClient.UseBasicAuthentication := False;
     lClient.ReadTimeOut(0);
     if not FJWT.IsEmpty then
-      lClient.RequestHeaders.Values['Authentication'] := 'bearer ' + FJWT;
+      lClient.RequestHeaders.Values['Authorization'] := 'bearer ' + FJWT;
     lQueryStringParams := TStringList.Create;
     try
       lQueryStringParams.Values['firstname'] := 'Daniele';
@@ -70,9 +71,12 @@ begin
   { Getting HTML response }
   lClient := TRESTClient.Create('localhost', 8080);
   try
+    // when the JWT authorization header is named "Authorization", the basic authorization must be disabled
+    lClient.UseBasicAuthentication := False;
+
     lClient.ReadTimeOut(0);
     if not FJWT.IsEmpty then
-      lClient.RequestHeaders.Values['Authentication'] := 'bearer ' + FJWT;
+      lClient.RequestHeaders.Values['Authorization'] := 'bearer ' + FJWT;
     lQueryStringParams := TStringList.Create;
     try
       lQueryStringParams.Values['firstname'] := 'Daniele';
@@ -100,8 +104,8 @@ begin
   try
     lClient.ReadTimeOut(0);
     lClient
-      .Header('jwtusername', 'user1')
-      .Header('jwtpassword', 'user1');
+      .Header('username', 'user1')
+      .Header('password', 'user1');
     lRest := lClient.doPOST('/login', []);
     if lRest.HasError then
     begin


### PR DESCRIPTION
JWT Middleware Altered to Allow Insert custom headers Authentication, Username and Password.
Change the names of the headers when adding Middleware to Engine.

In some cases of precise use send the user name and password in a header with a different name than the standard JWT Middleware. My token must be submitted in a custom header.
I could create a custom JWT authentication scheme, but I changed the middleware to, in case other developers also need something like that also can use this.

Note: If the token header is changed to "Authorization" the OnParseAuthentication event of the TIdHTTPWebBrokerBridge must be implemented.
``` pascal
class procedure TWebBrokerBridgeAuthEvent.ServerParserAuthentication(AContext: TIdContext; const AAuthType, AAuthData: String;
  var VUsername, VPassword: String; var VHandled: Boolean);
begin
  if SameText(AAuthType, 'bearer') then
    VHandled := True;
end;
``` 
Assign the event to the component:
``` pascal
  LServer := TIdHTTPWebBrokerBridge.Create(nil);
  try
    LServer.OnParseAuthentication := TWebBrokerBridgeAuthEvent.ServerParserAuthentication;
    // do something
  finally
    LServer.Free;
  end;

```
See the example .\samples\jsonwebtoken with these modifications