### PR TITLE
Added Boolean type support in RQLParser

### DIFF
--- a/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
+++ b/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
@@ -83,6 +83,13 @@ var
 begin
   if aRQLFIlter.RightValueType = vtString then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
+  else if aRQLFIlter.RightValueType = vtBoolean then
+  begin
+    if SameText(aRQLFIlter.OpRight, 'true') then
+      lValue := '1'
+    else
+      lValue := '0';
+  end
   else
     lValue := aRQLFIlter.OpRight;
 

--- a/sources/MVCFramework.RQL.AST2MSSQL.pas
+++ b/sources/MVCFramework.RQL.AST2MSSQL.pas
@@ -91,6 +91,13 @@ var
 begin
   if aRQLFIlter.RightValueType = vtString then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
+  else if aRQLFIlter.RightValueType = vtBoolean then
+  begin
+    if SameText(aRQLFIlter.OpRight, 'true') then
+      lValue := '1'
+    else
+      lValue := '0';
+  end
   else
     lValue := aRQLFIlter.OpRight;
 

--- a/sources/MVCFramework.RQL.AST2MySQL.pas
+++ b/sources/MVCFramework.RQL.AST2MySQL.pas
@@ -82,6 +82,13 @@ var
 begin
   if aRQLFIlter.RightValueType = vtString then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
+  else if aRQLFIlter.RightValueType = vtBoolean then
+  begin
+    if SameText(aRQLFIlter.OpRight, 'true') then
+      lValue := '1'
+    else
+      lValue := '0';
+  end
   else
     lValue := aRQLFIlter.OpRight;
 

--- a/tools/bin/rqlhistory.txt
+++ b/tools/bin/rqlhistory.txt
@@ -1,3 +1,5 @@
+eq(value,false)
+eq(value,true)
 in ( value , [ 1 , 2 , 3 ] ) 
 in ( value , [ 1 , 2 , 3 ] ) 
 in(value,[])


### PR DESCRIPTION
Added support for sending boolean values in rql.
Example: RQL eq(value,true) -> SQL WHERE (value = true)

In databases without native Boolean types (MySQL, MSSQL, Firebird), the value is converted to 0 or 1