### PR TITLE
Added support for comparisons with null fields

### DIFF
--- a/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
+++ b/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
@@ -98,7 +98,10 @@ begin
   case aRQLFIlter.Token of
     tkEq:
       begin
-        Result := Format('(%s = %s)', [lDBFieldName, lValue]);
+        if aRQLFIlter.RightValueType = vtNull then
+          Result := Format('(%s IS NULL)', [lDBFieldName])
+        else
+          Result := Format('(%s = %s)', [lDBFieldName, lValue]);
       end;
     tkLt:
       begin
@@ -118,7 +121,10 @@ begin
       end;
     tkNe:
       begin
-        Result := Format('(%s != %s)', [lDBFieldName, lValue]);
+        if aRQLFIlter.RightValueType = vtNull then
+          Result := Format('(%s IS NOT NULL)', [lDBFieldName])
+        else
+          Result := Format('(%s != %s)', [lDBFieldName, lValue]);
       end;
     tkContains:
       begin

--- a/sources/MVCFramework.RQL.AST2MSSQL.pas
+++ b/sources/MVCFramework.RQL.AST2MSSQL.pas
@@ -106,7 +106,10 @@ begin
   case aRQLFIlter.Token of
     tkEq:
       begin
-        Result := Format('(%s = %s)', [lDBFieldName, lValue]);
+        if aRQLFIlter.RightValueType = vtNull then
+          Result := Format('(%s IS NULL)', [lDBFieldName])
+        else
+          Result := Format('(%s = %s)', [lDBFieldName, lValue]);
       end;
     tkLt:
       begin
@@ -126,7 +129,10 @@ begin
       end;
     tkNe:
       begin
-        Result := Format('(%s != %s)', [lDBFieldName, lValue]);
+        if aRQLFIlter.RightValueType = vtNull then
+          Result := Format('(%s IS NOT NULL)', [lDBFieldName])
+        else
+          Result := Format('(%s != %s)', [lDBFieldName, lValue]);
       end;
     tkContains:
       begin

--- a/sources/MVCFramework.RQL.AST2MySQL.pas
+++ b/sources/MVCFramework.RQL.AST2MySQL.pas
@@ -97,7 +97,10 @@ begin
   case aRQLFIlter.Token of
     tkEq:
       begin
-        Result := Format('(%s = %s)', [lDBFieldName, lValue]);
+        if aRQLFIlter.RightValueType = vtNull then
+          Result := Format('(%s IS NULL)', [lDBFieldName])
+        else
+          Result := Format('(%s = %s)', [lDBFieldName, lValue]);
       end;
     tkLt:
       begin
@@ -117,7 +120,10 @@ begin
       end;
     tkNe:
       begin
-        Result := Format('(%s != %s)', [lDBFieldName, lValue]);
+        if aRQLFIlter.RightValueType = vtNull then
+          Result := Format('(%s IS NOT NULL)', [lDBFieldName])
+        else
+          Result := Format('(%s != %s)', [lDBFieldName, lValue]);
       end;
     tkContains:
       begin

--- a/sources/MVCFramework.RQL.AST2PostgreSQL.pas
+++ b/sources/MVCFramework.RQL.AST2PostgreSQL.pas
@@ -91,7 +91,10 @@ begin
   case aRQLFIlter.Token of
     tkEq:
       begin
-        Result := Format('(%s = %s)', [lDBFieldName, lValue]);
+        if aRQLFIlter.RightValueType = vtNull then
+          Result := Format('(%s IS NULL)', [lDBFieldName])
+        else
+          Result := Format('(%s = %s)', [lDBFieldName, lValue]);
       end;
     tkLt:
       begin
@@ -111,7 +114,10 @@ begin
       end;
     tkNe:
       begin
-        Result := Format('(%s != %s)', [lDBFieldName, lValue]);
+        if aRQLFIlter.RightValueType = vtNull then
+          Result := Format('(%s IS NOT NULL)', [lDBFieldName])
+        else
+          Result := Format('(%s != %s)', [lDBFieldName, lValue]);
       end;
     tkContains:
       begin

--- a/sources/MVCFramework.RQL.AST2SQLite.pas
+++ b/sources/MVCFramework.RQL.AST2SQLite.pas
@@ -92,7 +92,10 @@ begin
   case aRQLFIlter.Token of
     tkEq:
       begin
-        Result := Format('(%s = %s)', [lDBFieldName, lValue]);
+        if aRQLFIlter.RightValueType = vtNull then
+          Result := Format('(%s IS NULL)', [lDBFieldName])
+        else
+          Result := Format('(%s = %s)', [lDBFieldName, lValue]);
       end;
     tkLt:
       begin
@@ -112,7 +115,10 @@ begin
       end;
     tkNe:
       begin
-        Result := Format('(%s != %s)', [lDBFieldName, lValue]);
+        if aRQLFIlter.RightValueType = vtNull then
+          Result := Format('(%s IS NOT NULL)', [lDBFieldName])
+        else
+          Result := Format('(%s != %s)', [lDBFieldName, lValue]);
       end;
     tkContains:
       begin

--- a/sources/MVCFramework.RQL.Parser.pas
+++ b/sources/MVCFramework.RQL.Parser.pas
@@ -78,7 +78,7 @@ type
     tkOpenPar, tkClosedPar, tkOpenBracket, tkCloseBracket, tkComma, tkSemicolon, tkPlus, tkMinus, tkDblQuote,
     tkQuote, tkSpace, tkContains, tkIn, tkUnknown);
 
-  TRQLValueType = (vtInteger, vtString, vtBoolean, vtIntegerArray, vtStringArray);
+  TRQLValueType = (vtInteger, vtString, vtBoolean, vtNull, vtIntegerArray, vtStringArray);
 
   TRQLCustom = class;
 
@@ -188,6 +188,7 @@ type
     function MatchFieldNumericValue(out lFieldValue: string): Boolean;
     function MatchFieldArrayValue(out lFieldValue: string): Boolean;
     function MatchFieldBooleanValue(out lFieldValue: string): Boolean;
+    function MatchFieldNullValue(out lFieldValue: string): Boolean;
     function MatchSymbol(const Symbol: Char): Boolean;
     procedure SaveCurPos;
     procedure BackToLastPos;
@@ -618,10 +619,12 @@ begin
 
     if MatchFieldBooleanValue(lFieldValue) then
       lValueType := vtBoolean
+    else if MatchFieldNullValue(LFieldValue) then
+      lValueType := vtNull
     else if MatchFieldNumericValue(lFieldValue) then
       lValueType := vtInteger
     else
-      Error('Expected numeric or boolean value');
+      Error('Expected numeric, boolean or null value');
   end;
   EatWhiteSpaces;
   if GetToken <> tkClosedPar then
@@ -909,6 +912,23 @@ begin
   end
   else
     Exit(False);
+end;
+
+function TRQL2SQL.MatchFieldNullValue(out lFieldValue: string): Boolean;
+var
+  lChar: Char;
+begin
+  lFieldValue := '';
+  lChar := C(0).ToLower;
+
+  if (lChar = 'n') and (C(1).ToLower = 'u') and (C(2).ToLower = 'l') and (C(3).ToLower = 'l') then
+  begin
+    Skip(4);
+    Result := True;
+    lFieldValue := 'NULL';
+  end
+  else
+    Exit(False)
 end;
 
 function TRQL2SQL.MatchFieldNumericValue(out lFieldValue: string): Boolean;

--- a/tools/bin/rqlhistory.txt
+++ b/tools/bin/rqlhistory.txt
@@ -1,3 +1,5 @@
+ne(value,null)
+eq(value,null)
 eq(value,false)
 eq(value,true)
 in ( value , [ 1 , 2 , 3 ] ) 


### PR DESCRIPTION
Added support for comparisons with null fields:
rql: eq(value,null) -> sql: where (value IS NULL)
rql: ne(value,null) -> sql: where (value IS NOT NULL)