### PR TITLE
JWT Token Encoding Enhancements

### DIFF
--- a/sources/MVCFramework.Commons.pas
+++ b/sources/MVCFramework.Commons.pas
@@ -517,7 +517,7 @@ function B64Decode(const aValue: string): string;
 
 function URLSafeB64encode(const Value: string; IncludePadding: Boolean; AByteEncoding: IIdTextEncoding = nil): string; overload;
 function URLSafeB64encode(const Value: TBytes; IncludePadding: Boolean): string; overload;
-function URLSafeB64Decode(const Value: string): string;
+function URLSafeB64Decode(const Value: string; AByteEncoding: IIdTextEncoding = nil): string;
 
 function ByteToHex(AInByte: Byte): string;
 function BytesToHex(ABytes: TBytes): string;
@@ -1030,18 +1030,18 @@ begin
     Result := RTrim(TURLSafeEncode.EncodeBytes(TIdBytes(Value)), '=');
 end;
 
-function URLSafeB64Decode(const Value: string): string;
+function URLSafeB64Decode(const Value: string; AByteEncoding: IIdTextEncoding = nil): string;
 begin
   // SGR 2017-07-03 : b64url might not include padding. Need to add it before decoding
   case Length(Value) mod 4 of
     0:
       begin
-        Result := TURLSafeDecode.DecodeString(Value);
+        Result := TURLSafeDecode.DecodeString(Value, AByteEncoding);
       end;
     2:
-      Result := TURLSafeDecode.DecodeString(Value + '==');
+      Result := TURLSafeDecode.DecodeString(Value + '==', AByteEncoding);
     3:
-      Result := TURLSafeDecode.DecodeString(Value + '=');
+      Result := TURLSafeDecode.DecodeString(Value + '=', AByteEncoding);
   else
     raise EExternalException.Create('Illegal base64url length');
   end;

--- a/sources/MVCFramework.JWT.pas
+++ b/sources/MVCFramework.JWT.pas
@@ -30,7 +30,7 @@ interface
 
 uses
   System.Generics.Collections,
-  System.JSON,
+  JsonDataObjects,
   MVCFramework,
   MVCFramework.Patches;
 
@@ -191,12 +191,12 @@ type
     FLeewaySeconds: Cardinal;
     procedure SetHMACAlgorithm(const Value: string);
     procedure SetChecks(const Value: TJWTCheckableClaims);
-    function CheckExpirationTime(Payload: TJSONObject; out Error: string): Boolean;
-    function CheckNotBefore(Payload: TJSONObject; out Error: string): Boolean;
-    function CheckIssuedAt(Payload: TJSONObject; out Error: string): Boolean;
+    function CheckExpirationTime(Payload: TJDOJSONObject; out Error: string): Boolean;
+    function CheckNotBefore(Payload: TJDOJSONObject; out Error: string): Boolean;
+    function CheckIssuedAt(Payload: TJDOJSONObject; out Error: string): Boolean;
     procedure SetLiveValidityWindowInSeconds(const Value: Cardinal);
     function GetLiveValidityWindowInSeconds: Cardinal;
-    function IsValidToken(const Token: string; out Header, Payload: TJSONObject; out Error: string): Boolean;
+    function IsValidToken(const Token: string; out Header, Payload: TJDOJSONObject; out Error: string): Boolean;
   public
     constructor Create(const SecretKey: string; const ALeewaySeconds: Cardinal = 300); virtual;
     destructor Destroy; override;
@@ -218,10 +218,11 @@ type
 implementation
 
 uses
-  System.SysUtils
-    , MVCFramework.Commons
-    , MVCFramework.HMAC
-    , System.DateUtils;
+  System.SysUtils,
+  MVCFramework.Commons,
+  MVCFramework.HMAC,
+  System.DateUtils,
+  IdGlobal;
 
 { TJWTRegisteredClaims }
 
@@ -354,22 +355,19 @@ end;
 
 { TJWT }
 
-function TJWT.CheckExpirationTime(Payload: TJSONObject;
-  out Error: string): Boolean;
+function TJWT.CheckExpirationTime(Payload: TJDOJSONObject; out Error: string): Boolean;
 var
-  lJValue: TJSONValue;
   lIntValue: Int64;
   lValue: string;
   lExpirationTimeAsDateTime: TDateTime;
 begin
-  lJValue := Payload.GetValue(TJWTRegisteredClaimNames.ExpirationTime);
-  if not Assigned(lJValue) then
+  if not Payload.Contains(TJWTRegisteredClaimNames.ExpirationTime) then
   begin
     Error := TJWTRegisteredClaimNames.ExpirationTime + ' not set';
     Exit(False);
   end;
 
-  lValue := lJValue.Value;
+  lValue := Payload.S[TJWTRegisteredClaimNames.ExpirationTime];
   if not TryStrToInt64(lValue, lIntValue) then
   begin
     Error := TJWTRegisteredClaimNames.ExpirationTime + ' is not an integer';
@@ -386,20 +384,18 @@ begin
   Result := True;
 end;
 
-function TJWT.CheckIssuedAt(Payload: TJSONObject; out Error: string): Boolean;
+function TJWT.CheckIssuedAt(Payload: TJDOJSONObject; out Error: string): Boolean;
 var
-  lJValue: TJSONValue;
   lIntValue: Int64;
   lValue: string;
 begin
-  lJValue := Payload.GetValue(TJWTRegisteredClaimNames.IssuedAt);
-  if not Assigned(lJValue) then
+  if not Payload.Contains(TJWTRegisteredClaimNames.IssuedAt) then
   begin
     Error := TJWTRegisteredClaimNames.IssuedAt + ' not set';
     Exit(False);
   end;
 
-  lValue := lJValue.Value;
+  lValue := Payload.S[TJWTRegisteredClaimNames.IssuedAt];
   if not TryStrToInt64(lValue, lIntValue) then
   begin
     Error := TJWTRegisteredClaimNames.IssuedAt + ' is not an integer';
@@ -415,20 +411,18 @@ begin
   Result := True;
 end;
 
-function TJWT.CheckNotBefore(Payload: TJSONObject; out Error: string): Boolean;
+function TJWT.CheckNotBefore(Payload: TJDOJSONObject; out Error: string): Boolean;
 var
-  lJValue: TJSONValue;
   lIntValue: Int64;
   lValue: string;
 begin
-  lJValue := Payload.GetValue(TJWTRegisteredClaimNames.NotBefore);
-  if not Assigned(lJValue) then
+  if not Payload.Contains(TJWTRegisteredClaimNames.NotBefore) then
   begin
     Error := TJWTRegisteredClaimNames.NotBefore + ' not set';
     Exit(False);
   end;
 
-  lValue := lJValue.Value;
+  lValue := Payload.S[TJWTRegisteredClaimNames.NotBefore];
   if not TryStrToInt64(lValue, lIntValue) then
   begin
     Error := TJWTRegisteredClaimNames.NotBefore + ' is not an integer';
@@ -452,8 +446,7 @@ begin
   FCustomClaims := TJWTCustomClaims.Create;
   FHMACAlgorithm := HMAC_HS512;
   FLeewaySeconds := ALeewaySeconds;
-  FRegClaimsToChecks := [TJWTCheckableClaim.ExpirationTime, TJWTCheckableClaim.NotBefore,
-    TJWTCheckableClaim.IssuedAt];
+  FRegClaimsToChecks := [TJWTCheckableClaim.ExpirationTime, TJWTCheckableClaim.NotBefore, TJWTCheckableClaim.IssuedAt];
 end;
 
 destructor TJWT.Destroy;
@@ -470,17 +463,18 @@ end;
 
 function TJWT.GetToken: string;
 var
-  lHeader, lPayload: TJSONObject;
+  lHeader, lPayload: TJDOJSONObject;
   lHeaderEncoded, lPayloadEncoded, lToken, lHash: string;
   lBytes: TBytes;
   lRegClaimName: string;
   lCustomClaimName: string;
 begin
-  lHeader := TJSONObject.Create;
+  lHeader := TJDOJSONObject.Create;
   try
-    lPayload := TJSONObject.Create;
+    lPayload := TJDOJSONObject.Create;
     try
-      lHeader.AddPair('alg', HMACAlgorithm).AddPair('typ', 'JWT');
+      lHeader.S['alg'] :=  HMACAlgorithm;
+      lHeader.S['typ'] := 'JWT';
       for lRegClaimName in TJWTRegisteredClaimNames.Names do
       begin
         if FRegisteredClaims.Contains(lRegClaimName) then
@@ -488,23 +482,22 @@ begin
           if (lRegClaimName = TJWTRegisteredClaimNames.ExpirationTime) or
             (lRegClaimName = TJWTRegisteredClaimNames.NotBefore) or
             (lRegClaimName = TJWTRegisteredClaimNames.IssuedAt) then
-            lPayload.AddPair(lRegClaimName,
-              TJSONNumber.Create(StrToInt64(FRegisteredClaims[lRegClaimName])))
+            lPayload.L[lRegClaimName] := StrToInt64(FRegisteredClaims[lRegClaimName])
           else
-            lPayload.AddPair(lRegClaimName, FRegisteredClaims[lRegClaimName]);
+            lPayload.S[lRegClaimName] := FRegisteredClaims[lRegClaimName];
         end;
       end;
 
       for lCustomClaimName in FCustomClaims.Keys do
       begin
-        lPayload.AddPair(lCustomClaimName, FCustomClaims[lCustomClaimName]);
+        lPayload.S[lCustomClaimName] :=  FCustomClaims[lCustomClaimName];
       end;
 
-      lHeaderEncoded := URLSafeB64encode(lHeader.ToString, False);
-      lPayloadEncoded := URLSafeB64encode(lPayload.ToString, False);
+      lHeaderEncoded := URLSafeB64encode(lHeader.ToString, False, IndyTextEncoding_UTF8);
+      lPayloadEncoded := URLSafeB64encode(lPayload.ToString, False, IndyTextEncoding_UTF8);
       lToken := lHeaderEncoded + '.' + lPayloadEncoded;
       lBytes := HMAC(HMACAlgorithm, lToken, FSecretKey);
-      lHash := URLSafeB64encode(lBytes, false);
+      lHash := URLSafeB64encode(lBytes, False);
       Result := lToken + '.' + lHash;
     finally
       lPayload.Free;
@@ -514,10 +507,9 @@ begin
   end;
 end;
 
-function TJWT.IsValidToken(const Token: string; out Header, Payload: TJSONObject; out Error: string): Boolean;
+function TJWT.IsValidToken(const Token: string; out Header, Payload: TJDOJSONObject; out Error: string): Boolean;
 var
   lPieces: TArray<string>;
-  lJAlg: TJSONString;
   lAlgName: string;
 begin
   Result := False;
@@ -529,7 +521,7 @@ begin
     Exit(False);
   end;
 
-  Header := TJSONObject.ParseJSONValue(URLSafeB64Decode(lPieces[0])) as TJSONObject;
+  Header := TJDOJsonBaseObject.Parse(URLSafeB64Decode(lPieces[0], IndyTextEncoding_UTF8)) as TJDOJSONObject;
   try
     if not Assigned(Header) then
     begin
@@ -537,7 +529,7 @@ begin
       Exit(False);
     end;
 
-    Payload := TJSONObject.ParseJSONValue(URLSafeB64Decode(lPieces[1])) as TJSONObject;
+    Payload := TJDOJsonBaseObject.Parse(URLSafeB64Decode(lPieces[1], IndyTextEncoding_UTF8)) as TJDOJSONObject;
     try
       if not Assigned(Payload) then
       begin
@@ -545,18 +537,15 @@ begin
         Exit(False);
       end;
 
-      if not Header.TryGetValue<TJSONString>('alg', lJAlg) then
+      if not Header.Contains('alg') then
       begin
         Error := 'Invalid Token';
         Exit(False);
       end;
 
-      lAlgName := lJAlg.Value;
+      lAlgName := Header.S['alg'];
       Result := Token = lPieces[0] + '.' + lPieces[1] + '.' +
-        URLSafeB64encode(
-        HMAC(lAlgName, lPieces[0] + '.' + lPieces[1], FSecretKey),
-        False
-        );
+        URLSafeB64encode(HMAC(lAlgName, lPieces[0] + '.' + lPieces[1], FSecretKey), False);
 
       // if the token is correctly signed and has not been tampered,
       // let's check it's validity usinf nbf, exp, iat as configured in
@@ -602,9 +591,8 @@ end;
 function TJWT.LoadToken(const Token: string; out Error: string): Boolean;
 var
   lPieces: TArray<string>;
-  lJHeader: TJSONObject;
-  lJPayload: TJSONObject;
-  lJPair: TJSONPair;
+  lJHeader: TJDOJSONObject;
+  lJPayload: TJDOJSONObject;
   i: Integer;
   lName: string;
   j: Integer;
@@ -629,9 +617,9 @@ begin
     for i := 0 to lJPayload.Count - 1 do
     begin
       lIsRegistered := False;
-      lJPair := lJPayload.Pairs[i];
-      lName := lJPair.JsonString.Value;
-      lValue := lJPair.JsonValue.Value;
+
+      lName := lJPayload.Names[I];
+      lValue := lJPayload.Items[I].Value;
 
       // if is a registered claim, load it in the proper dictionary...
       for j := 0 to high(TJWTRegisteredClaimNames.Names) do


### PR DESCRIPTION
* When adding to the JWT Token a Payload containing special characters and accent was not decoded correctly by the client application. It has been fixed by encoding the Token as a Base64 with UTF-8 charset.

* System.JSON was changed by JsonDataObjects in unit MVCFramework.JWT