### PR TITLE
Removed hint

### DIFF
--- a/lib/loggerpro/LoggerPro.FileAppender.pas
+++ b/lib/loggerpro/LoggerPro.FileAppender.pas
@@ -291,8 +291,7 @@ var
   lFileStream: TFileStream;
   lFileAccessMode: Word;
   lRetries: Integer;
-begin
-  Result := nil;
+begin  
   lFileAccessMode := fmOpenWrite or fmShareDenyNone;
   if not TFile.Exists(aFileName) then
     lFileAccessMode := lFileAccessMode or fmCreate;


### PR DESCRIPTION
[dcc32 Hint] LoggerPro.FileAppender.pas(295): H2077 Value assigned to 'TLoggerProFileAppender.CreateWriter' never used