### PR TITLE
Removed warning

### DIFF
--- a/sources/MVCFramework.Middleware.Compression.pas
+++ b/sources/MVCFramework.Middleware.Compression.pas
@@ -118,7 +118,7 @@ begin
     Context.Response.Content := '';
     lContentStream.Size := 0;
     lContentStream.CopyFrom(lMemStream, 0);
-    Context.Response.RawWebResponse.ContentEncoding := MVC_COMPRESSION_TYPE_AS_STRING[lRespCompressionType];
+    Context.Response.RawWebResponse.ContentEncoding := string(MVC_COMPRESSION_TYPE_AS_STRING[lRespCompressionType]);
   finally
     lMemStream.Free;
   end;	


### PR DESCRIPTION
[dcc32 Warning] MVCFramework.Middleware.Compression.pas(121): W1057 Implicit string cast from 'AnsiString' to 'string'