### PR TITLE
Serializer Enhancements

### DIFF
--- a/sources/MVCFramework.Serializer.JsonDataObjects.pas
+++ b/sources/MVCFramework.Serializer.JsonDataObjects.pas
@@ -731,6 +731,7 @@ var
   ChildListOfAtt: MVCListOfAttribute;
   LEnumAsAttr: MVCEnumSerializationTypeAttribute;
   LEnumPrefix: string;
+  LClazz: TClass;
 begin
   if GetTypeSerializers.ContainsKey(AValue.TypeInfo) then
   begin
@@ -845,10 +846,14 @@ begin
           else
           begin
             ChildList := TDuckTypedList.Wrap(ChildObject);
-            if TMVCSerializerHelper.AttributeExists<MVCListOfAttribute>(ACustomAttributes,
-              ChildListOfAtt) then
-              JsonArrayToList(AJsonObject.A[AName], ChildList, ChildListOfAtt.Value,
-                AType, AIgnored)
+
+            if TMVCSerializerHelper.AttributeExists<MVCListOfAttribute>(ACustomAttributes, ChildListOfAtt) then
+              LClazz := ChildListOfAtt.Value
+            else
+              LClazz := GetObjectTypeOfGenericList(AValue.TypeInfo);
+
+            if Assigned(LClazz) then
+              JsonArrayToList(AJsonObject.A[AName], ChildList, LClazz, AType, AIgnored)
             else
               raise EMVCDeserializationException.CreateFmt
                 ('You can not deserialize a list %s without the MVCListOf attribute.', [AName]);

--- a/unittests/common/MVCFramework.Tests.Serializer.Entities.pas
+++ b/unittests/common/MVCFramework.Tests.Serializer.Entities.pas
@@ -354,6 +354,19 @@ type
     property Description: string read GetDescription write SetDescription;
   end;
 
+  TGenericEntity<T: class> = class
+  private
+    FCode: Integer;
+    FItems: TObjectList<T>;
+    FDescription: string;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    property Code: Integer read FCode write FCode;
+    property Description: string read FDescription write FDescription;
+    property Items: TObjectList<T> read FItems write FItems;
+  end;
+
 
 implementation
 
@@ -491,6 +504,20 @@ end;
 procedure TChildEntity.SetDescription(const Value: string);
 begin
   FDescription := Value;
+end;
+
+{ TGenericEntity<T> }
+
+constructor TGenericEntity<T>.Create;
+begin
+  inherited Create;
+  FItems := TObjectList<T>.Create;
+end;
+
+destructor TGenericEntity<T>.Destroy;
+begin
+  FItems.Free;
+  inherited Destroy;
 end;
 
 end.

--- a/unittests/general/Several/Serializers.JsonDataObjectsTestU.pas
+++ b/unittests/general/Several/Serializers.JsonDataObjectsTestU.pas
@@ -107,6 +107,9 @@ type
     procedure TestSerializeDeserializeGuid;
     [Test]
     procedure TestSerializeDeserializeEntityWithInterface;
+
+    [Test]
+    procedure TestSerializeDeserializeGenericEntity;
   end;
 
   TMVCEntityCustomSerializerJsonDataObjects = class(TInterfacedObject, IMVCTypeSerializer)
@@ -1312,6 +1315,61 @@ begin
   Assert.AreEqual('João Antônio Duarte', LEntity.Name);
   Assert.AreEqual(Integer(10), LEntity.ChildEntity.Code);
   Assert.AreEqual('Child Entity', LEntity.ChildEntity.Description);
+end;
+
+procedure TMVCTestSerializerJsonDataObjects.TestSerializeDeserializeGenericEntity;
+const
+  JSON =
+    '{' +
+    '"Code":1,'  +
+    '"Description":"General Description",' +
+    '"Items":[' +
+    '{"Description":"Description 01"},' +
+    '{"Description":"Description 02"},' +
+    '{"Description":"Description 03"},' +
+    '{"Description":"Description 04"},' +
+    '{"Description":"Description 05"}' +
+    ']'+
+    '}';
+var
+  LGenericEntity: TGenericEntity<TNote>;
+  LJson: string;
+begin
+  LGenericEntity := TGenericEntity<TNote>.Create;
+  try
+    LGenericEntity.Code := 1;
+    LGenericEntity.Description := 'General Description';
+
+    LGenericEntity.Items.Add(TNote.Create('Description 01'));
+    LGenericEntity.Items.Add(TNote.Create('Description 02'));
+    LGenericEntity.Items.Add(TNote.Create('Description 03'));
+    LGenericEntity.Items.Add(TNote.Create('Description 04'));
+    LGenericEntity.Items.Add(TNote.Create('Description 05'));
+
+    LJson := FSerializer.SerializeObject(LGenericEntity);
+
+    Assert.AreEqual(JSON, LJson);
+  finally
+    LGenericEntity.Free;
+  end;
+
+  LGenericEntity := TGenericEntity<TNote>.Create;
+  try
+    FSerializer.DeserializeObject(LJson, LGenericEntity);
+
+    Assert.AreEqual(Integer(1), LGenericEntity.Code);
+    Assert.AreEqual('General Description', LGenericEntity.Description);
+    Assert.AreEqual(Integer(5), LGenericEntity.Items.Count);
+    Assert.AreEqual('Description 01', LGenericEntity.Items[0].Description);
+    Assert.AreEqual('Description 02', LGenericEntity.Items[1].Description);
+    Assert.AreEqual('Description 03', LGenericEntity.Items[2].Description);
+    Assert.AreEqual('Description 04', LGenericEntity.Items[3].Description);
+    Assert.AreEqual('Description 05', LGenericEntity.Items[4].Description);
+
+  finally
+    LGenericEntity.Free;
+  end;
+
 end;
 
 procedure TMVCTestSerializerJsonDataObjects.TestSerializeDeserializeGuid;


### PR DESCRIPTION
Added support for deserializing generic lists without MVCListOf attribute.

It is now possible to deserialize a generic class like this:

```` pascal
  TGenericEntity<T: class> = class
  private
    FCode: Integer;
    FItems: TObjectList<T>;
    FDescription: string;
  public
    constructor Create;
    destructor Destroy; override;
    property Code: Integer read FCode write FCode;
    property Description: string read FDescription write FDescription;
    // MVCListOf(T) <- No need
    property Items: TObjectList<T> read FItems write FItems;
  end;
```` 
Before it was not possible because you should add the MVCListOf attribute to the TObjectList type property and you could not define a generic type to the MVCListOf attribute.