### PR TITLE
#293 Fix error "[dcc32 Error] MVCFramework.Swagger.Commons.pas(376): E2029 Statement expected but 'VAR' found"

### DIFF
--- a/sources/MVCFramework.Swagger.Commons.pas
+++ b/sources/MVCFramework.Swagger.Commons.pas
@@ -372,8 +372,6 @@ var
   lJsonSchema: TJsonField;
   lJsonRoot: TJsonFieldObject;
 begin
-  var
-  lClassName := AClass.ClassName;
   if AIsArray then
   begin
     lJsonSchema := TJsonFieldArray.Create


### PR DESCRIPTION
Removes the variable "lClassName" declared inline e not used.