### PR TITLE
Swagger improvements

### DIFF
--- a/samples/swaggerdoc/MyController2U.pas
+++ b/samples/swaggerdoc/MyController2U.pas
@@ -75,7 +75,9 @@ type
     [MVCPath('')]
     [MVCHTTPMethod([httpGET])]
     [MVCSwagSummary('People', 'List all persons', 'getPeople')]
-    [MVCSwagParam(plQuery, 'per_page', 'Items per page', ptInteger)]
+    [MVCSwagParam(plQuery, 'per_page', 'Items per page', ptInteger, False, '50')]
+    [MVCSwagParam(plQuery, 'enumparam', 'Enum param sample', ptString, False, 'enumvalue1',
+      'enumvalue1,enumvalue2,enumvalue3,enumvalue4')]
     [MVCSwagResponses(200, 'Success', TPerson, True)]
     [MVCSwagResponses(500, 'Internal Server Error')]
     procedure GetAllPeople;

--- a/sources/MVCFramework.Middleware.Swagger.pas
+++ b/sources/MVCFramework.Middleware.Swagger.pas
@@ -345,14 +345,36 @@ end;
 
 procedure TMVCSwaggerMiddleware.SortApiPaths(ASwagDoc: TSwagDoc);
 var
-  lComparer: IComparer<TSwagPath>;
+  lPathComparer: IComparer<TSwagPath>;
+  lOperationComparer: IComparer<TSwagPathOperation>;
+  lSwagPath: TSwagPath;
 begin
-  lComparer := TDelegatedComparer<TSwagPath>.Create(
+  // Sort paths
+  lPathComparer := TDelegatedComparer<TSwagPath>.Create(
   function(const Left, Right: TSwagPath): Integer
   begin
     Result := CompareText(Left.Operations[0].Tags[0], Right.Operations[0].Tags[0]);
   end);
-  ASwagDoc.Paths.Sort(lComparer);
+
+  ASwagDoc.Paths.Sort(lPathComparer);
+
+  // Sort paths operations
+  lOperationComparer := TDelegatedComparer<TSwagPathOperation>.Create(
+  function(const Left, Right: TSwagPathOperation): Integer
+  begin
+    if Ord(Left.Operation) > Ord(Right.Operation) then
+      Result := -1
+    else if Ord(Left.Operation) < Ord(Right.Operation) then
+      Result := 1
+    else
+      Result := 0;
+  end);
+
+  for lSwagPath in ASwagDoc.Paths do
+  begin
+    lSwagPath.Operations.Sort(lOperationComparer);
+  end;
+
 end;
 
 end.

--- a/sources/MVCFramework.Middleware.Swagger.pas
+++ b/sources/MVCFramework.Middleware.Swagger.pas
@@ -185,12 +185,13 @@ begin
           for I in lMVCHttpMethods do
           begin
             lSwagPathOp := TSwagPathOperation.Create;
-            TMVCSwagger.FillOperationSummary(lSwagPathOp, lMethod);
+            TMVCSwagger.FillOperationSummary(lSwagPathOp, lMethod, ASwagDoc.Definitions);
             if TMVCSwagger.MethodRequiresAuthentication(lMethod, lObjType, lAuthTypeName) then
             begin
               lSwagPathOp.Security.Add(lAuthTypeName);
             end;
-            lSwagPathOp.Parameters.AddRange(TMVCSwagger.GetParamsFromMethod(lSwagPath.Uri, lMethod));
+            lSwagPathOp.Parameters.AddRange(TMVCSwagger.GetParamsFromMethod(lSwagPath.Uri, lMethod,
+              ASwagDoc.Definitions));
             lSwagPathOp.Operation := TMVCSwagger.MVCHttpMethodToSwagPathOperation(I);
             lSwagPath.Operations.Add(lSwagPathOp);
           end;

--- a/sources/MVCFramework.Middleware.Swagger.pas
+++ b/sources/MVCFramework.Middleware.Swagger.pas
@@ -49,6 +49,7 @@ type
     procedure DocumentApiSettings(AContext: TWebContext; ASwagDoc: TSwagDoc);
     procedure DocumentApiAuthentication(const ASwagDoc: TSwagDoc);
     procedure DocumentApi(ASwagDoc: TSwagDoc);
+    procedure SortApiPaths(ASwagDoc: TSwagDoc);
     procedure InternalRender(AContent: string; AContext: TWebContext);
   public
     constructor Create(const AEngine: TMVCEngine; const ASwaggerInfo: TMVCSwaggerInfo;
@@ -76,7 +77,8 @@ uses
   Swag.Doc.Path.Operation.RequestParameter,
   Swag.Doc.SecurityDefinitionApiKey,
   Swag.Doc.SecurityDefinitionBasic,
-  Swag.Doc.Definition;
+  Swag.Doc.Definition,
+  System.Generics.Defaults;
 
 { TMVCSwaggerMiddleware }
 
@@ -329,6 +331,7 @@ begin
       DocumentApiSettings(AContext, LSwagDoc);
       DocumentApiAuthentication(LSwagDoc);
       DocumentApi(LSwagDoc);
+      SortApiPaths(LSwagDoc);
 
       LSwagDoc.GenerateSwaggerJson;
       InternalRender(LSwagDoc.SwaggerJson.Format, AContext);
@@ -338,6 +341,18 @@ begin
       LSwagDoc.Free;
     end;
   end;
+end;
+
+procedure TMVCSwaggerMiddleware.SortApiPaths(ASwagDoc: TSwagDoc);
+var
+  lComparer: IComparer<TSwagPath>;
+begin
+  lComparer := TDelegatedComparer<TSwagPath>.Create(
+  function(const Left, Right: TSwagPath): Integer
+  begin
+    Result := CompareText(Left.Operations[0].Tags[0], Right.Operations[0].Tags[0]);
+  end);
+  ASwagDoc.Paths.Sort(lComparer);
 end;
 
 end.

--- a/sources/MVCFramework.Swagger.Commons.pas
+++ b/sources/MVCFramework.Swagger.Commons.pas
@@ -134,14 +134,16 @@ type
     fJsonSchema: string;
     fJsonSchemaClass: TClass;
     fDefaultValue: string;
+    fEnumValues: string;
+    function GetEnumValues: TArray<string>;
   public
     constructor Create(const AParamLocation: TMVCSwagParamLocation; const AParamName: string;
       const AParamDescription: string; const AParamType: TMVCSwagParamType; const ARequired: Boolean = True;
-      const ADefaultValue: string = ''; const AJsonSchema: string = ''); overload;
+      const ADefaultValue: string = ''; const AEnumValues: string = ''; const AJsonSchema: string = ''); overload;
     constructor Create(const AParamLocation: TMVCSwagParamLocation; const AParamName: string;
       const AParamDescription: string; const AJsonSchemaClass: TClass;
       const AParamType: TMVCSwagParamType = ptNotDefined; const ARequired: Boolean = True;
-      const ADefaultValue: string = ''); overload;
+      const ADefaultValue: string = ''; const AEnumValues: string = ''); overload;
 
     property ParamLocation: TMVCSwagParamLocation read fParamLocation;
     property ParamName: string read fParamName;
@@ -149,6 +151,7 @@ type
     property ParamType: TMVCSwagParamType read fParamType;
     property Required: Boolean read fRequired;
     property DefaultValue: string read fDefaultValue;
+    property EnumValues: TArray<string> read GetEnumValues;
     property JsonSchema: string read fJsonSchema;
     property JsonSchemaClass: TClass read fJsonSchemaClass;
   end;
@@ -716,6 +719,7 @@ begin
           lSwagParam.InLocation := MVCParamLocationToSwagRequestParamInLocation(lMVCParam.ParamLocation);
           lSwagParam.Required := lMVCParam.Required;
           lSwagParam.Default := lMVCParam.DefaultValue;
+          lSwagParam.Enum.Text := string.Join(sLineBreak, lMVCParam.EnumValues);
           lSwagParam.TypeParameter := MVCParamTypeToSwagTypeParameter(lMVCParam.ParamType);
           lSwagParam.Description := lMVCParam.ParamDescription;
           if not lMVCParam.JsonSchema.IsEmpty then
@@ -773,6 +777,7 @@ begin
     lSwagParam.InLocation := MVCParamLocationToSwagRequestParamInLocation(lMVCSwagParams[I].ParamLocation);
     lSwagParam.Required := lMVCSwagParams[I].Required;
     lSwagParam.Default := lMVCSwagParams[I].DefaultValue;
+    lSwagParam.Enum.Text := string.Join(sLineBreak, lMVCSwagParams[I].EnumValues);
     lSwagParam.TypeParameter := MVCParamTypeToSwagTypeParameter(lMVCSwagParams[I].ParamType);
     lSwagParam.Description := lMVCSwagParams[I].ParamDescription;
     if not lMVCSwagParams[I].JsonSchema.IsEmpty then
@@ -940,7 +945,7 @@ end;
 
 constructor MVCSwagParamAttribute.Create(const AParamLocation: TMVCSwagParamLocation;
   const AParamName, AParamDescription: string; const AParamType: TMVCSwagParamType; const ARequired: Boolean;
-  const ADefaultValue, AJsonSchema: string);
+  const ADefaultValue, AEnumValues, AJsonSchema: string);
 begin
   fParamLocation := AParamLocation;
   fParamName := AParamName;
@@ -948,16 +953,22 @@ begin
   fParamType := AParamType;
   fRequired := ARequired;
   fDefaultValue := ADefaultValue;
+  fEnumValues := AEnumValues;
   fJsonSchema := AJsonSchema;
   fJsonSchemaClass := nil;
 end;
 
 constructor MVCSwagParamAttribute.Create(const AParamLocation: TMVCSwagParamLocation;
   const AParamName, AParamDescription: string; const AJsonSchemaClass: TClass; const AParamType: TMVCSwagParamType;
-  const ARequired: Boolean; const ADefaultValue: string);
+  const ARequired: Boolean; const ADefaultValue, AEnumValues: string);
 begin
-  Create(AParamLocation, AParamName, AParamDescription, AParamType, ARequired, ADefaultValue, '');
+  Create(AParamLocation, AParamName, AParamDescription, AParamType, ARequired, ADefaultValue, AEnumValues, '');
   fJsonSchemaClass := AJsonSchemaClass;
+end;
+
+function MVCSwagParamAttribute.GetEnumValues: TArray<string>;
+begin
+  Result := fEnumValues.Split([',', ';']);
 end;
 
 { MVCSwagJSONSchemaFieldAttribute }

--- a/sources/MVCFramework.Swagger.Commons.pas
+++ b/sources/MVCFramework.Swagger.Commons.pas
@@ -133,19 +133,22 @@ type
     fRequired: Boolean;
     fJsonSchema: string;
     fJsonSchemaClass: TClass;
+    fDefaultValue: string;
   public
     constructor Create(const AParamLocation: TMVCSwagParamLocation; const AParamName: string;
       const AParamDescription: string; const AParamType: TMVCSwagParamType; const ARequired: Boolean = True;
-      const AJsonSchema: string = ''); overload;
+      const ADefaultValue: string = ''; const AJsonSchema: string = ''); overload;
     constructor Create(const AParamLocation: TMVCSwagParamLocation; const AParamName: string;
       const AParamDescription: string; const AJsonSchemaClass: TClass;
-      const AParamType: TMVCSwagParamType = ptNotDefined; const ARequired: Boolean = True); overload;
+      const AParamType: TMVCSwagParamType = ptNotDefined; const ARequired: Boolean = True;
+      const ADefaultValue: string = ''); overload;
 
     property ParamLocation: TMVCSwagParamLocation read fParamLocation;
     property ParamName: string read fParamName;
     property ParamDescription: string read fParamDescription;
     property ParamType: TMVCSwagParamType read fParamType;
     property Required: Boolean read fRequired;
+    property DefaultValue: string read fDefaultValue;
     property JsonSchema: string read fJsonSchema;
     property JsonSchemaClass: TClass read fJsonSchemaClass;
   end;
@@ -712,6 +715,7 @@ begin
           lSwagParam.Name := lParamName;
           lSwagParam.InLocation := MVCParamLocationToSwagRequestParamInLocation(lMVCParam.ParamLocation);
           lSwagParam.Required := lMVCParam.Required;
+          lSwagParam.Default := lMVCParam.DefaultValue;
           lSwagParam.TypeParameter := MVCParamTypeToSwagTypeParameter(lMVCParam.ParamType);
           lSwagParam.Description := lMVCParam.ParamDescription;
           if not lMVCParam.JsonSchema.IsEmpty then
@@ -768,6 +772,7 @@ begin
     lSwagParam.Name := lMVCSwagParams[I].ParamName;
     lSwagParam.InLocation := MVCParamLocationToSwagRequestParamInLocation(lMVCSwagParams[I].ParamLocation);
     lSwagParam.Required := lMVCSwagParams[I].Required;
+    lSwagParam.Default := lMVCSwagParams[I].DefaultValue;
     lSwagParam.TypeParameter := MVCParamTypeToSwagTypeParameter(lMVCSwagParams[I].ParamType);
     lSwagParam.Description := lMVCSwagParams[I].ParamDescription;
     if not lMVCSwagParams[I].JsonSchema.IsEmpty then
@@ -935,22 +940,23 @@ end;
 
 constructor MVCSwagParamAttribute.Create(const AParamLocation: TMVCSwagParamLocation;
   const AParamName, AParamDescription: string; const AParamType: TMVCSwagParamType; const ARequired: Boolean;
-  const AJsonSchema: string);
+  const ADefaultValue, AJsonSchema: string);
 begin
   fParamLocation := AParamLocation;
   fParamName := AParamName;
   fParamDescription := AParamDescription;
   fParamType := AParamType;
   fRequired := ARequired;
+  fDefaultValue := ADefaultValue;
   fJsonSchema := AJsonSchema;
   fJsonSchemaClass := nil;
 end;
 
 constructor MVCSwagParamAttribute.Create(const AParamLocation: TMVCSwagParamLocation;
   const AParamName, AParamDescription: string; const AJsonSchemaClass: TClass; const AParamType: TMVCSwagParamType;
-  const ARequired: Boolean);
+  const ARequired: Boolean; const ADefaultValue: string);
 begin
-  Create(AParamLocation, AParamName, AParamDescription, AParamType, ARequired, '');
+  Create(AParamLocation, AParamName, AParamDescription, AParamType, ARequired, ADefaultValue, '');
   fJsonSchemaClass := AJsonSchemaClass;
 end;
 


### PR DESCRIPTION
Some enhancements have been added to swagger middleware:

- Entities will be mapped in the definitions section. Issue #289. This feature is still in its early stages, many improvements can still be made.
- Added DefaultValue parameter to MVCSwagParamAttribute to enter default value of parameter. Issue #291 
- Added EnumValues parameter to MVCSwagParamAttribute to pass a list of possible values to the parameter. Issue #292 
- The paths display in swagger has been changed to be sorted by tags. Issue #305 