### PR TITLE
Rql bugfix

### DIFF
--- a/samples/rql2sql/RQL2SQL.dproj
+++ b/samples/rql2sql/RQL2SQL.dproj
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{FD44EB2E-3630-4DA7-A18A-D8F572433F4E}</ProjectGuid>
-        <ProjectVersion>18.7</ProjectVersion>
+        <ProjectVersion>18.8</ProjectVersion>
         <FrameworkType>VCL</FrameworkType>
         <MainSource>RQL2SQL.dpr</MainSource>
         <Base>True</Base>
@@ -165,9 +165,17 @@
                         <RemoteDir>classes</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>classes</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="AndroidFileProvider">
                     <Platform Name="Android">
+                        <RemoteDir>res\xml</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\xml</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -183,9 +191,23 @@
                         <RemoteDir>library\lib\armeabi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeArmeabiv7aFile">
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="AndroidLibnativeMipsFile">
                     <Platform Name="Android">
+                        <RemoteDir>library\lib\mips</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>library\lib\mips</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -195,9 +217,23 @@
                         <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\arm64-v8a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidServiceOutput_Android32">
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="AndroidSplashImageDef">
                     <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\drawable</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -207,9 +243,17 @@
                         <RemoteDir>res\values</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="AndroidSplashStylesV21">
                     <Platform Name="Android">
+                        <RemoteDir>res\values-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\values-v21</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -219,9 +263,17 @@
                         <RemoteDir>res\values</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="Android_DefaultAppIcon">
                     <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\drawable</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -231,9 +283,17 @@
                         <RemoteDir>res\drawable-xxhdpi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="Android_LauncherIcon36">
                     <Platform Name="Android">
+                        <RemoteDir>res\drawable-ldpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\drawable-ldpi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -243,9 +303,17 @@
                         <RemoteDir>res\drawable-mdpi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="Android_LauncherIcon72">
                     <Platform Name="Android">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\drawable-hdpi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -255,9 +323,17 @@
                         <RemoteDir>res\drawable-xhdpi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="Android_NotificationIcon24">
                     <Platform Name="Android">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\drawable-mdpi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -267,9 +343,17 @@
                         <RemoteDir>res\drawable-hdpi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="Android_NotificationIcon48">
                     <Platform Name="Android">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\drawable-xhdpi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -279,9 +363,17 @@
                         <RemoteDir>res\drawable-xxhdpi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="Android_NotificationIcon96">
                     <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -291,9 +383,17 @@
                         <RemoteDir>res\drawable-small</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-small</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="Android_SplashImage470">
                     <Platform Name="Android">
+                        <RemoteDir>res\drawable-normal</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\drawable-normal</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -303,15 +403,27 @@
                         <RemoteDir>res\drawable-large</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-large</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="Android_SplashImage960">
                     <Platform Name="Android">
                         <RemoteDir>res\drawable-xlarge</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xlarge</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="Android_Strings">
                     <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <RemoteDir>res\values</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -401,6 +513,9 @@
                 </DeployClass>
                 <DeployClass Name="File">
                     <Platform Name="Android">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
                         <Operation>0</Operation>
                     </Platform>
                     <Platform Name="iOSDevice32">
@@ -736,6 +851,9 @@
                     <Platform Name="Android">
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="ProjectiOSDeviceDebug">
                     <Platform Name="iOSDevice32">
@@ -828,6 +946,10 @@
                         <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\arm64-v8a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                     <Platform Name="iOSDevice32">
                         <Operation>1</Operation>
                     </Platform>
@@ -850,6 +972,12 @@
                     </Platform>
                     <Platform Name="Win32">
                         <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOutput_Android32">
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="ProjectUWPManifest">
@@ -889,6 +1017,7 @@
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
             </Deployment>
             <Platforms>
                 <Platform value="Win32">True</Platform>

--- a/samples/rql2sql/bin/rqlhistory.txt
+++ b/samples/rql2sql/bin/rqlhistory.txt
@@ -1,3 +1,5 @@
+and(eq(nome,"Marca d'água"), contains(nome,"Marca d'água"), in(nome, ["Marca", "D'água"]))
+and(eq(nome,"Marca d'água"), contains(nome,"Marca d'água"))
 ne(value,null)
 eq(value,null)
 eq(value,false)

--- a/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
+++ b/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
@@ -128,7 +128,7 @@ begin
       end;
     tkContains:
       begin
-        Result := Format('(%s containing ''%s'')', [lDBFieldName, lValue.DeQuotedString.ToLower])
+        Result := Format('(%s containing %s)', [lDBFieldName, lValue.ToLower])
       end;
     tkIn:
       begin
@@ -141,8 +141,8 @@ begin
             end;
           vtStringArray:
             begin
-              Result := Format('(%s IN (''%s''))', [
-                lDBFieldName, string.Join(''',''', aRQLFIlter.OpRightArray)
+              Result := Format('(%s IN (%s))', [
+                lDBFieldName, string.Join(',', QuoteStringArray(aRQLFIlter.OpRightArray))
                 ]);
             end;
         else

--- a/sources/MVCFramework.RQL.AST2MSSQL.pas
+++ b/sources/MVCFramework.RQL.AST2MSSQL.pas
@@ -89,7 +89,7 @@ function TRQLMSSQLCompiler.RQLFilterToSQL(const aRQLFIlter: TRQLFilter): string;
 var
   lValue, lDBFieldName: string;
 begin
-  if aRQLFIlter.RightValueType = vtString then
+  if (aRQLFIlter.RightValueType = vtString) and (aRQLFIlter.Token <> tkContains) then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
   else if aRQLFIlter.RightValueType = vtBoolean then
   begin
@@ -136,7 +136,8 @@ begin
       end;
     tkContains:
       begin
-        Result := Format('(LOWER(%s) LIKE ''%%%s%%'')', [lDBFieldName, lValue.DeQuotedString.ToLower])
+        lValue := Format('%%%s%%', [lValue]).QuotedString('''');
+        Result := Format('(LOWER(%s) LIKE %s)', [lDBFieldName, lValue.ToLower])
       end;
     tkIn:
       begin
@@ -149,8 +150,8 @@ begin
             end;
           vtStringArray:
             begin
-              Result := Format('(%s IN (''%s''))', [
-                lDBFieldName, string.Join(''',''', aRQLFIlter.OpRightArray)
+              Result := Format('(%s IN (%s))', [
+                lDBFieldName, string.Join(',', QuoteStringArray(aRQLFIlter.OpRightArray))
                 ]);
             end;
         else

--- a/sources/MVCFramework.RQL.AST2MySQL.pas
+++ b/sources/MVCFramework.RQL.AST2MySQL.pas
@@ -80,7 +80,7 @@ function TRQLMySQLCompiler.RQLFilterToSQL(const aRQLFIlter: TRQLFilter): string;
 var
   lValue, lDBFieldName: string;
 begin
-  if aRQLFIlter.RightValueType = vtString then
+  if (aRQLFIlter.RightValueType = vtString) and (aRQLFIlter.Token <> tkContains) then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
   else if aRQLFIlter.RightValueType = vtBoolean then
   begin
@@ -127,7 +127,8 @@ begin
       end;
     tkContains:
       begin
-        Result := Format('(LOWER(%s) LIKE ''%%%s%%'')', [lDBFieldName, lValue.DeQuotedString.ToLower])
+        lValue := Format('%%%s%%', [lValue]).QuotedString('''');
+        Result := Format('(LOWER(%s) LIKE %s)', [lDBFieldName, lValue.ToLower])
       end;
     tkIn:
       begin
@@ -140,8 +141,8 @@ begin
             end;
           vtStringArray:
             begin
-              Result := Format('(%s IN (''%s''))', [
-                lDBFieldName, string.Join(''',''', aRQLFIlter.OpRightArray)
+              Result := Format('(%s IN (%s))', [
+                lDBFieldName, string.Join(',', QuoteStringArray(aRQLFIlter.OpRightArray))
                 ]);
             end;
         else

--- a/sources/MVCFramework.RQL.AST2PostgreSQL.pas
+++ b/sources/MVCFramework.RQL.AST2PostgreSQL.pas
@@ -81,7 +81,7 @@ function TRQLPostgreSQLCompiler.RQLFilterToSQL(const aRQLFIlter: TRQLFilter): st
 var
   lValue, lDBFieldName: string;
 begin
-  if aRQLFIlter.RightValueType = vtString then
+  if (aRQLFIlter.RightValueType = vtString) and (aRQLFIlter.Token <> tkContains) then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
   else
     lValue := aRQLFIlter.OpRight;
@@ -121,7 +121,8 @@ begin
       end;
     tkContains:
       begin
-        Result := Format('(%s ILIKE ''%%%s%%'')', [lDBFieldName, lValue.DeQuotedString.ToLower])
+        lValue := Format('%%%s%%', [lValue]).QuotedString('''');
+        Result := Format('(%s ILIKE %s)', [lDBFieldName, lValue.ToLower])
       end;
     tkIn:
       begin
@@ -134,8 +135,8 @@ begin
             end;
           vtStringArray:
             begin
-              Result := Format('(%s IN (''%s''))', [
-                lDBFieldName, string.Join(''',''', aRQLFIlter.OpRightArray)
+              Result := Format('(%s IN (%s))', [
+                lDBFieldName, string.Join(',', QuoteStringArray(aRQLFIlter.OpRightArray))
                 ]);
             end;
         else

--- a/sources/MVCFramework.RQL.AST2SQLite.pas
+++ b/sources/MVCFramework.RQL.AST2SQLite.pas
@@ -82,7 +82,7 @@ function TRQLSQLiteCompiler.RQLFilterToSQL(const aRQLFIlter: TRQLFilter): string
 var
   lValue, lDBFieldName: string;
 begin
-  if aRQLFIlter.RightValueType = vtString then
+  if (aRQLFIlter.RightValueType = vtString) and (aRQLFIlter.Token <> tkContains) then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
   else
     lValue := aRQLFIlter.OpRight;
@@ -122,7 +122,8 @@ begin
       end;
     tkContains:
       begin
-        Result := Format('(%s LIKE ''%%%s%%'')', [lDBFieldName, lValue.DeQuotedString.ToLower])
+        lValue := Format('%%%s%%', [lValue]).QuotedString('''');
+        Result := Format('(%s LIKE %s)', [lDBFieldName, lValue.ToLower])
       end;
     tkIn:
       begin
@@ -135,8 +136,8 @@ begin
             end;
           vtStringArray:
             begin
-              Result := Format('(%s IN (''%s''))', [
-                lDBFieldName, string.Join(''',''', aRQLFIlter.OpRightArray)
+              Result := Format('(%s IN (%s))', [
+                lDBFieldName, string.Join(',', QuoteStringArray(aRQLFIlter.OpRightArray))
                 ]);
             end;
         else

--- a/sources/MVCFramework.RQL.Parser.pas
+++ b/sources/MVCFramework.RQL.Parser.pas
@@ -93,6 +93,7 @@ type
     fMapping: TMVCFieldsMapping;
   protected
     function GetDatabaseFieldName(const RQLPropertyName: string): string;
+    function QuoteStringArray(const aStringArray: TArray<string>): TArray<string>;
   public
     constructor Create(const Mapping: TMVCFieldsMapping); virtual;
     procedure AST2SQL(const aRQLAST: TRQLAbstractSyntaxTree; out aSQL: string); virtual; abstract;
@@ -1150,6 +1151,18 @@ begin
   end;
   raise ERQLException.CreateFmt('Property %s does not exist or is transient and cannot be used in RQL',
     [RQLPropertyName]);
+end;
+
+function TRQLCompiler.QuoteStringArray(const aStringArray: TArray<string>): TArray<string>;
+var
+  lValue: string;
+begin
+  SetLength(Result, 0);
+  for lValue in aStringArray do
+  begin
+    SetLength(Result, Length(Result) + 1);
+    Result[High(Result)] := lValue.QuotedString('''');
+  end;
 end;
 
 { TRQLAbstractSyntaxTree }


### PR DESCRIPTION
Fixed error in the RQL compiler when passing a string containing the apostrophe (') symbol in the `contains` and `in` operators.

Before:
| rql | sql |
| ------ | ------ |
| `contains(nome,"marca d'água")` | `where (nome like '%marca d'água%')` |

Now:
| rql | sql |
| ------ | ------ |
| `contains(nome,"marca d'água")` | `where (nome like '%marca d''água%')` |