### PR TITLE
Added authentication key for redis connection

### DIFF
--- a/sources/MVCFramework.Controllers.CacheController.pas
+++ b/sources/MVCFramework.Controllers.CacheController.pas
@@ -171,12 +171,13 @@ end;
 
 function TMVCCacheController.RedisClient: IRedisClient;
 var
-  lConnection: string;
+  lConnection, lKeyAuth: string;
   lPieces: TArray<string>;
 begin
   if (FRedis = nil) then
   begin
     lConnection := self.Config['redis_connection_string'];
+    lKeyAuth := self.Config['redis_connection_key'];
     if lConnection.Trim.IsEmpty then
       raise ERedisException.Create('"redis_connection_string" config key is not defined (format is <host>:<port>)')
     else
@@ -184,7 +185,11 @@ begin
       lPieces := lConnection.Split([':']);
       if Length(lPieces) <> 2 then
         raise ERedisException.Create('Invalid "redis_connection_string" (format is <host>:<port>)');
+
       FRedis := NewRedisClient(lPieces[0], StrToInt(lPieces[1]));
+
+      if not String.IsNullOrWhiteSpace(lConnection) then
+        FRedis.AUTH(lKeyAuth);
     end;
   end;
   Result := FRedis;


### PR DESCRIPTION
There was a need to enter the authentication key to connect to redis.

1. TMVCEngine added, Config ['redis_connection_key']: = KeyAuth, to enter the key.

2. TMVCCacheController.RedisClient modified to retrieve the key and pass on the creation of a new connection.