### PR TITLE
Added `out` operator in RQL parser

### DIFF
--- a/samples/rql2sql/bin/rqlhistory.txt
+++ b/samples/rql2sql/bin/rqlhistory.txt
@@ -1,3 +1,5 @@
+out(name,["daniele","scott"])
+out ( value , [ 1 , 2 , 3 ] ) 
 and(eq(nome,"Marca d'água"), contains(nome,"Marca d'água"), in(nome, ["Marca", "D'água"]))
 and(eq(nome,"Marca d'água"), contains(nome,"Marca d'água"))
 ne(value,null)

--- a/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
+++ b/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
@@ -149,6 +149,25 @@ begin
           raise ERQLException.Create('Invalid RightValueType for tkIn');
         end;
       end;
+    tkOut:
+      begin
+        case aRQLFIlter.RightValueType of
+          vtIntegerArray:
+            begin
+              Result := Format('(%s NOT IN (%s))', [
+                lDBFieldName, string.Join(',', aRQLFIlter.OpRightArray)
+                ]);
+            end;
+          vtStringArray:
+            begin
+              Result := Format('(%s NOT IN (%s))', [
+                lDBFieldName, string.Join(',', QuoteStringArray(aRQLFIlter.OpRightArray))
+                ]);
+            end;
+        else
+          raise ERQLException.Create('Invalid RightValueType for tkOut');
+        end;
+      end;
   end;
 end;
 

--- a/sources/MVCFramework.RQL.AST2MSSQL.pas
+++ b/sources/MVCFramework.RQL.AST2MSSQL.pas
@@ -158,6 +158,25 @@ begin
           raise ERQLException.Create('Invalid RightValueType for tkIn');
         end;
       end;
+    tkOut:
+      begin
+        case aRQLFIlter.RightValueType of
+          vtIntegerArray: // if array is empty, RightValueType is always vtIntegerArray
+            begin
+              Result := Format('(%s NOT IN (%s))', [
+                lDBFieldName, string.Join(',', aRQLFIlter.OpRightArray)
+                ]);
+            end;
+          vtStringArray:
+            begin
+              Result := Format('(%s NOT IN (%s))', [
+                lDBFieldName, string.Join(',', QuoteStringArray(aRQLFIlter.OpRightArray))
+                ]);
+            end;
+        else
+          raise ERQLException.Create('Invalid RightValueType for tkOut');
+        end;
+      end;
   end;
 end;
 

--- a/sources/MVCFramework.RQL.AST2MySQL.pas
+++ b/sources/MVCFramework.RQL.AST2MySQL.pas
@@ -149,6 +149,25 @@ begin
           raise ERQLException.Create('Invalid RightValueType for tkIn');
         end;
       end;
+    tkOut:
+      begin
+        case aRQLFIlter.RightValueType of
+          vtIntegerArray:
+            begin
+              Result := Format('(%s NOT IN (%s))', [
+                lDBFieldName, string.Join(',', aRQLFIlter.OpRightArray)
+                ]);
+            end;
+          vtStringArray:
+            begin
+              Result := Format('(%s NOT IN (%s))', [
+                lDBFieldName, string.Join(',', QuoteStringArray(aRQLFIlter.OpRightArray))
+                ]);
+            end;
+        else
+          raise ERQLException.Create('Invalid RightValueType for tkOut');
+        end;
+      end;
   end;
 end;
 

--- a/sources/MVCFramework.RQL.AST2PostgreSQL.pas
+++ b/sources/MVCFramework.RQL.AST2PostgreSQL.pas
@@ -143,6 +143,25 @@ begin
           raise ERQLException.Create('Invalid RightValueType for tkIn');
         end;
       end;
+    tkOut:
+      begin
+        case aRQLFIlter.RightValueType of
+          vtIntegerArray:
+            begin
+              Result := Format('(%s NOT IN (%s))', [
+                GetFieldNameForSQL(lDBFieldName), string.Join(',', aRQLFIlter.OpRightArray)
+                ]);
+            end;
+          vtStringArray:
+            begin
+              Result := Format('(%s NOT IN (%s))', [
+                GetFieldNameForSQL(lDBFieldName), string.Join(',', QuoteStringArray(aRQLFIlter.OpRightArray))
+                ]);
+            end;
+        else
+          raise ERQLException.Create('Invalid RightValueType for tkOut');
+        end;
+      end;
   end;
 end;
 

--- a/sources/MVCFramework.RQL.AST2SQLite.pas
+++ b/sources/MVCFramework.RQL.AST2SQLite.pas
@@ -144,6 +144,25 @@ begin
           raise ERQLException.Create('Invalid RightValueType for tkIn');
         end;
       end;
+    tkOut:
+      begin
+        case aRQLFIlter.RightValueType of
+          vtIntegerArray:
+            begin
+              Result := Format('(%s NOT IN (%s))', [
+                lDBFieldName, string.Join(',', aRQLFIlter.OpRightArray)
+                ]);
+            end;
+          vtStringArray:
+            begin
+              Result := Format('(%s NOT IN (%s))', [
+                lDBFieldName, string.Join(',', QuoteStringArray(aRQLFIlter.OpRightArray))
+                ]);
+            end;
+        else
+          raise ERQLException.Create('Invalid RightValueType for tkOut');
+        end;
+      end;
   end;
 end;
 

--- a/sources/MVCFramework.RQL.Parser.pas
+++ b/sources/MVCFramework.RQL.Parser.pas
@@ -53,14 +53,13 @@ uses
   limit(count,start,maxCount) - Returns the given range of objects from the result set
   contains(<property>,<value | expression>) - Filters for objects where the specified property's value is an array and the array contains any value that equals the provided value or satisfies the provided expression.
   in(<property>,<array-of-values>) - Filters for objects where the specified property's value is in the provided array
-
+  out(<property>,<array-of-values>) - Filters for objects where the specified property's value is not in the provided array
 
   //////NOT AVAILABLES
   select(<property>,<property>,...) - Trims each object down to the set of properties defined in the arguments
   values(<property>) - Returns an array of the given property value for each object
   aggregate(<property|function>,...) - Aggregates the array, grouping by objects that are distinct for the provided properties, and then reduces the remaining other property values using the provided functions
   distinct() - Returns a result set with duplicates removed
-  out(<property>,<array-of-values>) - Filters for objects where the specified property's value is not in the provided array
   excludes(<property>,<value | expression>) - Filters for objects where the specified property's value is an array and the array does not contain any of value that equals the provided value or satisfies the provided expression.
   rel(<relation name?>,<query>) - Applies the provided query against the linked data of the provided relation name.
   sum(<property?>) - Finds the sum of every value in the array or if the property argument is provided, returns the sum of the value of property for every object in the array
@@ -76,7 +75,7 @@ uses
 type
   TRQLToken = (tkEq, tkLt, tkLe, tkGt, tkGe, tkNe, tkAnd, tkOr, tkSort, tkLimit, { RQL } tkAmpersand, tkEOF,
     tkOpenPar, tkClosedPar, tkOpenBracket, tkCloseBracket, tkComma, tkSemicolon, tkPlus, tkMinus, tkDblQuote,
-    tkQuote, tkSpace, tkContains, tkIn, tkUnknown);
+    tkQuote, tkSpace, tkContains, tkIn, tkOut, tkUnknown);
 
   TRQLValueType = (vtInteger, vtString, vtBoolean, vtNull, vtIntegerArray, vtStringArray);
 
@@ -526,6 +525,12 @@ begin
     fCurrToken := tkIn;
     Exit(fCurrToken);
   end;
+  if (lChar = 'o') and (C(1) = 'u') and (C(2) = 't') then
+  begin
+    Skip(3);
+    fCurrToken := tkOut;
+    Exit(fCurrToken);
+  end;
   if (lChar = ' ') then
   begin
     fCurrToken := tkSpace;
@@ -578,7 +583,7 @@ begin
       Error('Unclosed string');
     lValueType := vtString;
   end
-  else if (aToken = tkIn) and (lToken = tkOpenBracket) then
+  else if (aToken in [tkIn, tkOut]) and (lToken = tkOpenBracket) then
   begin
     lList := TList<string>.Create;
     try
@@ -657,7 +662,7 @@ begin
   Result := true;
   lTk := GetToken;
   case lTk of
-    tkEq, tkLt, tkLe, tkGt, tkGe, tkNe, tkContains, tkIn:
+    tkEq, tkLt, tkLe, tkGt, tkGe, tkNe, tkContains, tkIn, tkOut:
       begin
         ParseBinOperator(lTk, fAST);
       end;
@@ -735,7 +740,7 @@ begin
     EatWhiteSpaces;
     lToken := GetToken;
     case lToken of
-      tkEq, tkLt, tkLe, tkGt, tkGe, tkNe, tkContains, tkIn:
+      tkEq, tkLt, tkLe, tkGt, tkGe, tkNe, tkContains, tkIn, tkOut:
         begin
           ParseBinOperator(lToken, lLogicOp.FilterAST);
         end;


### PR DESCRIPTION
Added support `out` operator in RQL parser.

The RQL `out` operator is equivalent to the SQL `NOT IN` operator.