### PR TITLE
Fixed memory leaks in SwagDoc Library

### DIFF
--- a/lib/swagdoc/Source/Swag.Doc.Definition.pas
+++ b/lib/swagdoc/Source/Swag.Doc.Definition.pas
@@ -70,7 +70,8 @@ uses
 
 destructor TSwagDefinition.Destroy;
 begin
-  FreeAndNil(fJsonSchema);
+  if Assigned(fJsonSchema) then
+    FreeAndNil(fJsonSchema);
   inherited Destroy;
 end;
 

--- a/lib/swagdoc/Source/Swag.Doc.Path.Operation.RequestParameter.pas
+++ b/lib/swagdoc/Source/Swag.Doc.Path.Operation.RequestParameter.pas
@@ -205,7 +205,7 @@ begin
     if (not fSchema.Name.IsEmpty) then
       vJsonObject.AddPair(c_SwagRequestParameterSchema, fSchema.GenerateJsonRefDefinition)
     else if Assigned(fSchema.JsonSchema) then
-      vJsonObject.AddPair(c_SwagRequestParameterSchema, fSchema.JsonSchema as TJSONObject);
+      vJsonObject.AddPair(c_SwagRequestParameterSchema, fSchema.JsonSchema.Clone as TJSONObject);
   end;
   if (fTypeParameter <> stpNotDefined) then
     vJsonObject.AddPair(c_SwagRequestParameterType, c_SwagTypeParameter[fTypeParameter]);

--- a/lib/swagdoc/Source/Swag.Doc.Path.Operation.Response.pas
+++ b/lib/swagdoc/Source/Swag.Doc.Path.Operation.Response.pas
@@ -144,7 +144,7 @@ begin
   if (not fSchema.Name.IsEmpty) then
     vJsonObject.AddPair(c_SwagResponseSchema, fSchema.GenerateJsonRefDefinition)
   else if Assigned(fSchema.JsonSchema) then
-    vJsonObject.AddPair(c_SwagResponseSchema, fSchema.JsonSchema as TJSONObject);
+    vJsonObject.AddPair(c_SwagResponseSchema, fSchema.JsonSchema.Clone as TJSONObject);
 
   if (fExamples.Count > 0) then
     vJsonObject.AddPair(c_SwagResponseExamples, GenerateExamplesJsonObject);
@@ -186,7 +186,7 @@ begin
   end;
 
   if Assigned(pJson.Values[c_SwagResponseSchema]) then
-    fSchema.JsonSchema := pJson.Values[c_SwagResponseSchema].Clone as TJSONObject
+    fSchema.JsonSchema := pJson.Values[c_SwagResponseSchema].Clone as TJSONObject;
 end;
 
 end.

--- a/lib/swagdoc/Source/Swag.Doc.pas
+++ b/lib/swagdoc/Source/Swag.Doc.pas
@@ -258,7 +258,7 @@ var
 begin
   Result := TJsonObject.Create;
   for vIndex := 0 to fDefinitions.Count -1 do
-    Result.AddPair(fDefinitions.Items[vIndex].Name, fDefinitions.Items[vIndex].JsonSchema);
+    Result.AddPair(fDefinitions.Items[vIndex].Name, fDefinitions.Items[vIndex].JsonSchema.Clone as TJSONObject);
 end;
 
 function TSwagDoc.GenerateParametersJsonObject: TJSONObject;

--- a/samples/swaggerdoc/SwaggerDocApi.dpr
+++ b/samples/swaggerdoc/SwaggerDocApi.dpr
@@ -2,6 +2,7 @@ program SwaggerDocApi;
 {$APPTYPE GUI}
 
 uses
+//  FastMM4,
   Vcl.Forms,
   Web.WebReq,
   IdHTTPWebBrokerBridge,

--- a/samples/swaggerdoc/SwaggerDocApi.dproj
+++ b/samples/swaggerdoc/SwaggerDocApi.dproj
@@ -103,11 +103,9 @@
         </DelphiCompile>
         <DCCReference Include="MainFormU.pas">
             <Form>MainForm</Form>
-            <FormType>dfm</FormType>
         </DCCReference>
         <DCCReference Include="WebModuleMainU.pas">
             <Form>WebModule1</Form>
-            <FormType>dfm</FormType>
             <DesignClass>TWebModule</DesignClass>
         </DCCReference>
         <DCCReference Include="MyController1U.pas"/>


### PR DESCRIPTION
There were some memory leaks that were only identified with the use of FastMM4.

Thanks to [maiconsi](https://github.com/maiconsi) for reporting this.

Fix #379 