### PR TITLE
Change SEATTLEORBETTER to TOKYOORBETTER in MVCFramework.Middleware.ETag

### DIFF
--- a/sources/MVCFramework.Middleware.ETag.pas
+++ b/sources/MVCFramework.Middleware.ETag.pas
@@ -56,7 +56,7 @@ type
 implementation
 
 uses
-{$IF defined(SEATTLEORBETTER)}
+{$IF defined(TOKYOORBETTER)}
   System.Hash,
 {$ELSE}
   IdHashMessageDigest,
@@ -67,12 +67,12 @@ uses
 { TMVCETagMiddleware }
 
 function TMVCETagMiddleware.GetHashMD5FromStream(AStream: TStream): string;
-{$IF not defined(SEATTLEORBETTER)}
+{$IF not defined(TOKYOORBETTER)}
 var
   lMD5Hash: TIdHashMessageDigest5;
 {$ENDIF}
 begin
-{$IF defined(SEATTLEORBETTER)}
+{$IF defined(TOKYOORBETTER)}
   Result := THashMD5.GetHashString(AStream);
 {$ELSE}
   lMD5Hash := TIdHashMessageDigest5.Create;


### PR DESCRIPTION
The current implementation of MVCFramework.Middleware.ETag doesn't work on Seattle and Berlin as the function

> class function GetHashString(const AStream: TStream): string; overload; static; inline;

was only added after Tokyo.

http://docwiki.embarcadero.com/Libraries/Seattle/en/System.Hash.THashMD5.GetHashString
http://docwiki.embarcadero.com/Libraries/Berlin/en/System.Hash.THashMD5.GetHashString
http://docwiki.embarcadero.com/Libraries/Tokyo/en/System.Hash.THashMD5.GetHashString