### PR TITLE
MVCNameCase improvements

### DIFF
--- a/sources/MVCFramework.Commons.pas
+++ b/sources/MVCFramework.Commons.pas
@@ -1393,6 +1393,7 @@ var
   lIsLowerCase: Boolean;
   lIsUpperCase, lPreviousWasUpperCase: Boolean;
   lIsAlpha: Boolean;
+  lIsNumber: Boolean;
 begin
   {TODO -oDanieleT -cGeneral : Make this function faster!}
   lNextUpCase := MakeFirstUpperToo;
@@ -1404,8 +1405,9 @@ begin
       C := Value.Chars[I];
       lIsLowerCase := CharInSet(C, ['a' .. 'z']);
       lIsUpperCase := CharInSet(C, ['A' .. 'Z']);
+      lIsNumber := CharInSet(C, ['0' .. '9']);
       lIsAlpha := lIsLowerCase or lIsUpperCase;
-      if not lIsAlpha then
+      if not (lIsAlpha or lIsNumber) then
       begin
         lNextUpCase := True;
         lPreviousWasUpperCase := False;
@@ -1431,6 +1433,10 @@ begin
         end;
       end;
       lPreviousWasUpperCase := lIsUpperCase;
+      if lIsNumber then
+      begin
+        lNextUpCase := True;
+      end;
     end;
     Result := lSB.ToString;
   finally
@@ -1448,10 +1454,13 @@ var
   lIsNumber: Boolean;
   lLastWasUnderscore: Boolean;
   lIsUnderscore: Boolean;
+  lLastWasNumber: Boolean;
+  lIsAlpha: Boolean;
 begin
   lCanInsertAnUnderscore := False;
   lLastWasLowercase := False;
   lLastWasUnderscore := False;
+  lLastWasNumber := False;
   lSB := TStringBuilder.Create;
   try
     for I := 0 to Length(Value) - 1 do
@@ -1461,9 +1470,11 @@ begin
       lIsLowerCase := CharInSet(C, ['a' .. 'z']);
       lIsNumber := CharInSet(C, ['0' .. '9']);
       lIsUnderscore := C = '_';
+      lIsAlpha := lIsUpperCase or lIsLowerCase;
 
-      lCanInsertAnUnderscore := lCanInsertAnUnderscore and lLastWasLowercase and (not lLastWasUnderscore);
-      if (lIsUpperCase or lIsNumber) and (I > 0) and lCanInsertAnUnderscore then
+      lCanInsertAnUnderscore := lCanInsertAnUnderscore and (lLastWasLowercase or lLastWasNumber) and
+        (not lLastWasUnderscore);
+      if (lIsUpperCase or lIsNumber or (lIsAlpha and lLastWasNumber)) and (I > 0) and lCanInsertAnUnderscore then
       begin
         lSB.Append('_');
         lCanInsertAnUnderscore := False;
@@ -1478,6 +1489,7 @@ begin
       end;
       lLastWasUnderscore := lIsUnderscore;
       lLastWasLowercase := lIsLowerCase;
+      lLastWasNumber := lIsNumber;
     end;
     Result := lSB.ToString;
   finally

--- a/sources/MVCFramework.Commons.pas
+++ b/sources/MVCFramework.Commons.pas
@@ -663,7 +663,8 @@ uses
   IdCoder3to4,
   System.NetEncoding,
   System.Character,
-  MVCFramework.Serializer.JsonDataObjects, MVCFramework.Serializer.Commons;
+  MVCFramework.Serializer.JsonDataObjects, MVCFramework.Serializer.Commons,
+  System.RegularExpressions;
 
 var
   GlobalAppName, GlobalAppPath, GlobalAppExe: string;
@@ -1438,40 +1439,49 @@ begin
 end;
 
 function SnakeCase(const Value: string): string;
-var
-  I: Integer;
-  lSB: TStringBuilder;
-  C: Char;
-  lIsUpperCase, lIsLowerCase, lLastWasLowercase: Boolean;
-  lCanInsertAnUnderscore: Boolean;
 begin
-  lCanInsertAnUnderscore := False;
-  lLastWasLowercase := False;
-  lSB := TStringBuilder.Create;
-  try
-    for I := 0 to Length(Value) - 1 do
-    begin
-      C := Value.Chars[I];
-      lIsUpperCase := CharInSet(C, ['A' .. 'Z']);
-      lIsLowerCase := CharInSet(C, ['a' .. 'z']);
-      lCanInsertAnUnderscore := lCanInsertAnUnderscore and lLastWasLowercase;
-      if lIsUpperCase and (I > 0) and lCanInsertAnUnderscore then
-      begin
-        lSB.Append('_');
-        lCanInsertAnUnderscore := False;
-      end
-      else
-      begin
-        lCanInsertAnUnderscore := True;
-      end;
-      lSB.Append(LowerCase(C));
-      lLastWasLowercase := lIsLowerCase;
-    end;
-    Result := lSB.ToString;
-  finally
-    lSB.Free;
-  end;
+  // Convert multiple underlines to just one
+  Result := TRegex.Replace(Value, '([_][_{1}]+)', '_');
+  // Adds underscores between a lowercase character and an uppercase character
+  Result := TRegex.Replace(Result, '([a-z0-9])([A-Z])', '\1_\2');
+  Result := Result.ToLower;
 end;
+
+//function SnakeCase(const Value: string): string;
+//var
+//  I: Integer;
+//  lSB: TStringBuilder;
+//  C: Char;
+//  lIsUpperCase, lIsLowerCase, lLastWasLowercase: Boolean;
+//  lCanInsertAnUnderscore: Boolean;
+//begin
+//  lCanInsertAnUnderscore := False;
+//  lLastWasLowercase := False;
+//  lSB := TStringBuilder.Create;
+//  try
+//    for I := 0 to Length(Value) - 1 do
+//    begin
+//      C := Value.Chars[I];
+//      lIsUpperCase := CharInSet(C, ['A' .. 'Z']);
+//      lIsLowerCase := CharInSet(C, ['a' .. 'z']);
+//      lCanInsertAnUnderscore := lCanInsertAnUnderscore and lLastWasLowercase;
+//      if lIsUpperCase and (I > 0) and lCanInsertAnUnderscore then
+//      begin
+//        lSB.Append('_');
+//        lCanInsertAnUnderscore := False;
+//      end
+//      else
+//      begin
+//        lCanInsertAnUnderscore := True;
+//      end;
+//      lSB.Append(LowerCase(C));
+//      lLastWasLowercase := lIsLowerCase;
+//    end;
+//    Result := lSB.ToString;
+//  finally
+//    lSB.Free;
+//  end;
+//end;
 
 function StrToJSONObject(const aString: String): TJsonObject;
 begin

--- a/sources/MVCFramework.Commons.pas
+++ b/sources/MVCFramework.Commons.pas
@@ -1439,49 +1439,51 @@ begin
 end;
 
 function SnakeCase(const Value: string): string;
+var
+  I: Integer;
+  lSB: TStringBuilder;
+  C: Char;
+  lIsUpperCase, lIsLowerCase, lLastWasLowercase: Boolean;
+  lCanInsertAnUnderscore: Boolean;
+  lIsNumber: Boolean;
+  lLastWasUnderscore: Boolean;
+  lIsUnderscore: Boolean;
 begin
-  // Convert multiple underlines to just one
-  Result := TRegex.Replace(Value, '([_][_]+)', '_');
-  // Adds underscores between a lowercase character and an uppercase character
-  Result := TRegex.Replace(Result, '([a-z0-9])([A-Z])', '\1_\2');
-  Result := Result.ToLower;
-end;
+  lCanInsertAnUnderscore := False;
+  lLastWasLowercase := False;
+  lLastWasUnderscore := False;
+  lSB := TStringBuilder.Create;
+  try
+    for I := 0 to Length(Value) - 1 do
+    begin
+      C := Value.Chars[I];
+      lIsUpperCase := CharInSet(C, ['A' .. 'Z']);
+      lIsLowerCase := CharInSet(C, ['a' .. 'z']);
+      lIsNumber := CharInSet(C, ['0' .. '9']);
+      lIsUnderscore := C = '_';
 
-//function SnakeCase(const Value: string): string;
-//var
-//  I: Integer;
-//  lSB: TStringBuilder;
-//  C: Char;
-//  lIsUpperCase, lIsLowerCase, lLastWasLowercase: Boolean;
-//  lCanInsertAnUnderscore: Boolean;
-//begin
-//  lCanInsertAnUnderscore := False;
-//  lLastWasLowercase := False;
-//  lSB := TStringBuilder.Create;
-//  try
-//    for I := 0 to Length(Value) - 1 do
-//    begin
-//      C := Value.Chars[I];
-//      lIsUpperCase := CharInSet(C, ['A' .. 'Z']);
-//      lIsLowerCase := CharInSet(C, ['a' .. 'z']);
-//      lCanInsertAnUnderscore := lCanInsertAnUnderscore and lLastWasLowercase;
-//      if lIsUpperCase and (I > 0) and lCanInsertAnUnderscore then
-//      begin
-//        lSB.Append('_');
-//        lCanInsertAnUnderscore := False;
-//      end
-//      else
-//      begin
-//        lCanInsertAnUnderscore := True;
-//      end;
-//      lSB.Append(LowerCase(C));
-//      lLastWasLowercase := lIsLowerCase;
-//    end;
-//    Result := lSB.ToString;
-//  finally
-//    lSB.Free;
-//  end;
-//end;
+      lCanInsertAnUnderscore := lCanInsertAnUnderscore and lLastWasLowercase and (not lLastWasUnderscore);
+      if (lIsUpperCase or lIsNumber) and (I > 0) and lCanInsertAnUnderscore then
+      begin
+        lSB.Append('_');
+        lCanInsertAnUnderscore := False;
+      end
+      else
+      begin
+        lCanInsertAnUnderscore := True;
+      end;
+      if not (lLastWasUnderscore and lIsUnderscore) then
+      begin
+        lSB.Append(LowerCase(C));
+      end;
+      lLastWasUnderscore := lIsUnderscore;
+      lLastWasLowercase := lIsLowerCase;
+    end;
+    Result := lSB.ToString;
+  finally
+    lSB.Free;
+  end;
+end;
 
 function StrToJSONObject(const aString: String): TJsonObject;
 begin

--- a/sources/MVCFramework.Commons.pas
+++ b/sources/MVCFramework.Commons.pas
@@ -1441,7 +1441,7 @@ end;
 function SnakeCase(const Value: string): string;
 begin
   // Convert multiple underlines to just one
-  Result := TRegex.Replace(Value, '([_][_{1}]+)', '_');
+  Result := TRegex.Replace(Value, '([_][_]+)', '_');
   // Adds underscores between a lowercase character and an uppercase character
   Result := TRegex.Replace(Result, '([a-z0-9])([A-Z])', '\1_\2');
   Result := Result.ToLower;

--- a/sources/MVCFramework.Serializer.Commons.pas
+++ b/sources/MVCFramework.Serializer.Commons.pas
@@ -59,7 +59,7 @@ type
 
   TMVCSerializationType = (stUnknown, stDefault, stProperties, stFields);
 
-  TMVCNameCase = (ncAsIs, ncUpperCase, ncLowerCase, ncCamelCase, ncPascalCase);
+  TMVCNameCase = (ncAsIs, ncUpperCase, ncLowerCase, ncCamelCase, ncPascalCase, ncSnakeCase);
 
   TMVCDataType = (dtObject, dtArray);
 
@@ -626,6 +626,10 @@ begin
     ncPascalCase:
       begin
         Result := CamelCase(Value, True);
+      end;
+    ncSnakeCase:
+      begin
+        Result := SnakeCase(Value);
       end;
     ncAsIs:
       begin

--- a/unittests/general/Several/FrameworkTestsU.pas
+++ b/unittests/general/Several/FrameworkTestsU.pas
@@ -1790,11 +1790,11 @@ end;
 
 procedure TTestNameCase.SetupFixture;
 begin
-  fOrigDATA[1] := 'one_two';
+  fOrigDATA[1] := 'one_two_3or4';
   fOrigDATA[2] := 'ONE_TWO_THREE';
   fOrigDATA[3] := 'JustOne';
   fOrigDATA[4] := '_with__underscores_';
-  fOrigDATA[5] := 'oneTwo___three';
+  fOrigDATA[5] := 'oneTwo___three04';
 
   fOutDATA[1][ncAsIs] := fOrigDATA[1];
   fOutDATA[2][ncAsIs] := fOrigDATA[2];
@@ -1802,35 +1802,35 @@ begin
   fOutDATA[4][ncAsIs] := fOrigDATA[4];
   fOutDATA[5][ncAsIs] := fOrigDATA[5];
 
-  fOutDATA[1][ncUpperCase] := 'ONE_TWO';
+  fOutDATA[1][ncUpperCase] := 'ONE_TWO_3OR4';
   fOutDATA[2][ncUpperCase] := 'ONE_TWO_THREE';
   fOutDATA[3][ncUpperCase] := 'JUSTONE';
   fOutDATA[4][ncUpperCase] := '_WITH__UNDERSCORES_';
-  fOutDATA[5][ncUpperCase] := 'ONETWO___THREE';
+  fOutDATA[5][ncUpperCase] := 'ONETWO___THREE04';
 
-  fOutDATA[1][ncLowerCase] := 'one_two';
+  fOutDATA[1][ncLowerCase] := 'one_two_3or4';
   fOutDATA[2][ncLowerCase] := 'one_two_three';
   fOutDATA[3][ncLowerCase] := 'justone';
   fOutDATA[4][ncLowerCase] := '_with__underscores_';
-  fOutDATA[5][ncLowerCase] := 'onetwo___three';
+  fOutDATA[5][ncLowerCase] := 'onetwo___three04';
 
-  fOutDATA[1][ncCamelCase] := 'oneTwo';
+  fOutDATA[1][ncCamelCase] := 'oneTwo3Or4';
   fOutDATA[2][ncCamelCase] := 'oneTwoThree';
   fOutDATA[3][ncCamelCase] := 'justOne';
   fOutDATA[4][ncCamelCase] := 'WithUnderscores';
-  fOutDATA[5][ncCamelCase] := 'oneTwoThree';
+  fOutDATA[5][ncCamelCase] := 'oneTwoThree04';
 
-  fOutDATA[1][ncPascalCase] := 'OneTwo';
+  fOutDATA[1][ncPascalCase] := 'OneTwo3Or4';
   fOutDATA[2][ncPascalCase] := 'OneTwoThree';
   fOutDATA[3][ncPascalCase] := 'JustOne';
   fOutDATA[4][ncPascalCase] := 'WithUnderscores';
-  fOutDATA[5][ncPascalCase] := 'OneTwoThree';
+  fOutDATA[5][ncPascalCase] := 'OneTwoThree04';
 
-  fOutDATA[1][ncSnakeCase] := 'one_two';
+  fOutDATA[1][ncSnakeCase] := 'one_two_3_or_4';
   fOutDATA[2][ncSnakeCase] := 'one_two_three';
   fOutDATA[3][ncSnakeCase] := 'just_one';
   fOutDATA[4][ncSnakeCase] := '_with_underscores_';
-  fOutDATA[5][ncSnakeCase] := 'one_two_three';
+  fOutDATA[5][ncSnakeCase] := 'one_two_three_04';
 
 end;
 

--- a/unittests/general/Several/FrameworkTestsU.pas
+++ b/unittests/general/Several/FrameworkTestsU.pas
@@ -199,8 +199,8 @@ type
   [TestFixture]
   TTestNameCase = class(TObject)
   private
-    fOutDATA: array [1 .. 4] of array [ncAsIs .. ncPascalCase] of string;
-    fOrigDATA: array [1 .. 4] of string;
+    fOutDATA: array [1 .. 5] of array [ncAsIs .. ncSnakeCase] of string;
+    fOrigDATA: array [1 .. 5] of string;
   public
     [SetupFixture]
     procedure SetupFixture;
@@ -1794,31 +1794,44 @@ begin
   fOrigDATA[2] := 'ONE_TWO_THREE';
   fOrigDATA[3] := 'JustOne';
   fOrigDATA[4] := '_with__underscores_';
+  fOrigDATA[5] := 'oneTwo___three';
 
   fOutDATA[1][ncAsIs] := fOrigDATA[1];
   fOutDATA[2][ncAsIs] := fOrigDATA[2];
   fOutDATA[3][ncAsIs] := fOrigDATA[3];
   fOutDATA[4][ncAsIs] := fOrigDATA[4];
+  fOutDATA[5][ncAsIs] := fOrigDATA[5];
 
   fOutDATA[1][ncUpperCase] := 'ONE_TWO';
   fOutDATA[2][ncUpperCase] := 'ONE_TWO_THREE';
   fOutDATA[3][ncUpperCase] := 'JUSTONE';
   fOutDATA[4][ncUpperCase] := '_WITH__UNDERSCORES_';
+  fOutDATA[5][ncUpperCase] := 'ONETWO___THREE';
 
   fOutDATA[1][ncLowerCase] := 'one_two';
   fOutDATA[2][ncLowerCase] := 'one_two_three';
   fOutDATA[3][ncLowerCase] := 'justone';
   fOutDATA[4][ncLowerCase] := '_with__underscores_';
+  fOutDATA[5][ncLowerCase] := 'onetwo___three';
 
   fOutDATA[1][ncCamelCase] := 'oneTwo';
   fOutDATA[2][ncCamelCase] := 'oneTwoThree';
   fOutDATA[3][ncCamelCase] := 'justOne';
   fOutDATA[4][ncCamelCase] := 'WithUnderscores';
+  fOutDATA[5][ncCamelCase] := 'oneTwoThree';
 
   fOutDATA[1][ncPascalCase] := 'OneTwo';
   fOutDATA[2][ncPascalCase] := 'OneTwoThree';
   fOutDATA[3][ncPascalCase] := 'JustOne';
   fOutDATA[4][ncPascalCase] := 'WithUnderscores';
+  fOutDATA[5][ncPascalCase] := 'OneTwoThree';
+
+  fOutDATA[1][ncSnakeCase] := 'one_two';
+  fOutDATA[2][ncSnakeCase] := 'one_two_three';
+  fOutDATA[3][ncSnakeCase] := 'just_one';
+  fOutDATA[4][ncSnakeCase] := '_with_underscores_';
+  fOutDATA[5][ncSnakeCase] := 'one_two_three';
+
 end;
 
 procedure TTestNameCase.TestNameCase;
@@ -1829,9 +1842,9 @@ var
   lOutData: string;
   lActualOutData: string;
 begin
-  for lNameCaseIdx := ncAsIs to ncPascalCase do
+  for lNameCaseIdx := ncAsIs to ncSnakeCase do
   begin
-    for I := 1 to 4 do
+    for I := 1 to 5 do
     begin
       lOrig := fOrigDATA[I];
       lOutData := fOutDATA[I][lNameCaseIdx];


### PR DESCRIPTION
I added a new type of name case serialization: `ncSnakeCase`

I saw that there was already a conversion function for the snake case, however it failed to convert multiple underscores to just one. So I switched to regular expression conversion.

Original | SnakeCase 
-------- | -------------
OneTwo | one_two 
One__Two | one_two
_OneTwo | _one_two