### PR TITLE
Fix: Does not compile with 10.0 Seattle

### DIFF
--- a/sources/MVCFramework.RESTClient.pas
+++ b/sources/MVCFramework.RESTClient.pas
@@ -1458,7 +1458,7 @@ begin
   lTmp := TMemoryStream.Create;
   try
     Result.Body.Position := 0;
-{$IF Defined(SeattleOrBetter)}
+{$IF Defined(BerlinOrBetter)}
     lDecomp := TZDecompressionStream.Create(Result.Body,
       MVC_COMPRESSION_ZLIB_WINDOW_BITS[lCompressionType], False);
 {$ELSE}


### PR DESCRIPTION
IFDEF was using "SeattleOrBetter", but it should be "BerlinOrBetter"

Fixes #446 