### PR TITLE
#558 - Implements "starts" operator in RQL parser

### DIFF
--- a/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
+++ b/sources/MVCFramework.RQL.AST2FirebirdSQL.pas
@@ -182,6 +182,10 @@ begin
       begin
         Result := Format('(%s containing %s)', [lDBFieldName, lValue.ToLower])
       end;
+    tkStarts:
+      begin
+        Result := Format('(%s starting with %s)', [lDBFieldName, lValue.ToLower])
+      end;
     tkIn:
       begin
         case aRQLFIlter.RightValueType of

--- a/sources/MVCFramework.RQL.AST2MSSQL.pas
+++ b/sources/MVCFramework.RQL.AST2MSSQL.pas
@@ -89,7 +89,7 @@ function TRQLMSSQLCompiler.RQLFilterToSQL(const aRQLFIlter: TRQLFilter): string;
 var
   lValue, lDBFieldName: string;
 begin
-  if (aRQLFIlter.RightValueType = vtString) and (aRQLFIlter.Token <> tkContains) then
+  if (aRQLFIlter.RightValueType = vtString) and not(aRQLFIlter.Token in [tkContains, tkStarts]) then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
   else if aRQLFIlter.RightValueType = vtBoolean then
   begin
@@ -137,6 +137,11 @@ begin
     tkContains:
       begin
         lValue := Format('%%%s%%', [lValue]).QuotedString('''');
+        Result := Format('(LOWER(%s) LIKE %s)', [lDBFieldName, lValue.ToLower])
+      end;
+    tkStarts:
+      begin
+        lValue := Format('%s%%', [lValue]).QuotedString('''');
         Result := Format('(LOWER(%s) LIKE %s)', [lDBFieldName, lValue.ToLower])
       end;
     tkIn:

--- a/sources/MVCFramework.RQL.AST2MySQL.pas
+++ b/sources/MVCFramework.RQL.AST2MySQL.pas
@@ -80,7 +80,7 @@ function TRQLMySQLCompiler.RQLFilterToSQL(const aRQLFIlter: TRQLFilter): string;
 var
   lValue, lDBFieldName: string;
 begin
-  if (aRQLFIlter.RightValueType = vtString) and (aRQLFIlter.Token <> tkContains) then
+  if (aRQLFIlter.RightValueType = vtString) and not(aRQLFIlter.Token in [tkContains, tkStarts]) then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
   else if aRQLFIlter.RightValueType = vtBoolean then
   begin
@@ -128,6 +128,11 @@ begin
     tkContains:
       begin
         lValue := Format('%%%s%%', [lValue]).QuotedString('''');
+        Result := Format('(LOWER(%s) LIKE %s)', [lDBFieldName, lValue.ToLower])
+      end;
+    tkStarts:
+      begin
+        lValue := Format('%s%%', [lValue]).QuotedString('''');
         Result := Format('(LOWER(%s) LIKE %s)', [lDBFieldName, lValue.ToLower])
       end;
     tkIn:

--- a/sources/MVCFramework.RQL.AST2PostgreSQL.pas
+++ b/sources/MVCFramework.RQL.AST2PostgreSQL.pas
@@ -81,7 +81,7 @@ function TRQLPostgreSQLCompiler.RQLFilterToSQL(const aRQLFIlter: TRQLFilter): st
 var
   lValue, lDBFieldName: string;
 begin
-  if (aRQLFIlter.RightValueType = vtString) and (aRQLFIlter.Token <> tkContains) then
+  if (aRQLFIlter.RightValueType = vtString) and not(aRQLFIlter.Token in [tkContains, tkStarts]) then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
   else
     lValue := aRQLFIlter.OpRight;
@@ -122,6 +122,11 @@ begin
     tkContains:
       begin
         lValue := Format('%%%s%%', [lValue]).QuotedString('''');
+        Result := Format('(%s ILIKE %s)', [GetFieldNameForSQL(lDBFieldName), lValue.ToLower])
+      end;
+    tkStarts:
+      begin
+        lValue := Format('%s%%', [lValue]).QuotedString('''');
         Result := Format('(%s ILIKE %s)', [GetFieldNameForSQL(lDBFieldName), lValue.ToLower])
       end;
     tkIn:

--- a/sources/MVCFramework.RQL.AST2SQLite.pas
+++ b/sources/MVCFramework.RQL.AST2SQLite.pas
@@ -82,7 +82,7 @@ function TRQLSQLiteCompiler.RQLFilterToSQL(const aRQLFIlter: TRQLFilter): string
 var
   lValue, lDBFieldName: string;
 begin
-  if (aRQLFIlter.RightValueType = vtString) and (aRQLFIlter.Token <> tkContains) then
+  if (aRQLFIlter.RightValueType = vtString) and not(aRQLFIlter.Token in [tkContains, tkStarts]) then
     lValue := aRQLFIlter.OpRight.QuotedString('''')
   else if aRQLFIlter.RightValueType = vtBoolean then
   begin
@@ -132,6 +132,11 @@ begin
     tkContains:
       begin
         lValue := Format('%%%s%%', [lValue]).QuotedString('''');
+        Result := Format('(%s LIKE %s)', [lDBFieldName, lValue.ToLower])
+      end;
+    tkStarts:
+      begin
+        lValue := Format('%s%%', [lValue]).QuotedString('''');
         Result := Format('(%s LIKE %s)', [lDBFieldName, lValue.ToLower])
       end;
     tkIn:

--- a/sources/MVCFramework.RQL.Parser.pas
+++ b/sources/MVCFramework.RQL.Parser.pas
@@ -75,7 +75,7 @@ uses
 type
   TRQLToken = (tkEq, tkLt, tkLe, tkGt, tkGe, tkNe, tkAnd, tkOr, tkSort, tkLimit, { RQL } tkAmpersand, tkEOF,
     tkOpenPar, tkClosedPar, tkOpenBracket, tkCloseBracket, tkComma, tkSemicolon, tkPlus, tkMinus, tkDblQuote,
-    tkQuote, tkSpace, tkContains, tkIn, tkOut, tkUnknown);
+    tkQuote, tkSpace, tkContains, tkIn, tkOut, tkUnknown, tkStarts);
 
   TRQLValueType = (vtInteger, vtString, vtBoolean, vtNull, vtIntegerArray, vtStringArray);
 
@@ -527,6 +527,12 @@ begin
     fCurrToken := tkContains;
     Exit(fCurrToken);
   end;
+  if (lChar = 's') and (C(1) = 't') and (C(2) = 'a') and (C(3) = 'r') and (C(4) = 't') and (C(5) = 's') then
+  begin
+    Skip(6);
+    fCurrToken := tkStarts;
+    Exit(fCurrToken);
+  end;
   if (lChar = 'i') and (C(1) = 'n') then
   begin
     Skip(2);
@@ -670,7 +676,7 @@ begin
   Result := true;
   lTk := GetToken;
   case lTk of
-    tkEq, tkLt, tkLe, tkGt, tkGe, tkNe, tkContains, tkIn, tkOut:
+    tkEq, tkLt, tkLe, tkGt, tkGe, tkNe, tkContains, tkStarts, tkIn, tkOut:
       begin
         ParseBinOperator(lTk, fAST);
       end;
@@ -748,7 +754,7 @@ begin
     EatWhiteSpaces;
     lToken := GetToken;
     case lToken of
-      tkEq, tkLt, tkLe, tkGt, tkGe, tkNe, tkContains, tkIn, tkOut:
+      tkEq, tkLt, tkLe, tkGt, tkGe, tkNe, tkContains, tkStarts, tkIn, tkOut:
         begin
           ParseBinOperator(lToken, lLogicOp.FilterAST);
         end;


### PR DESCRIPTION
The parser has been tested in Firebird but not in the rest of database platforms. I've tried to guess the code, but further testing would be needed.