### PR TITLE
Fixed wrong data type for NullableTGUID

### DIFF
--- a/sources/MVCFramework.ActiveRecord.pas
+++ b/sources/MVCFramework.ActiveRecord.pas
@@ -2039,7 +2039,7 @@ begin
       begin
         if not aValue.AsType<NullableTGUID>().HasValue then
         begin
-          aParam.DataType := TFieldType.ftCurrency;
+          aParam.DataType := TFieldType.ftGuid;
           aParam.Clear;
           Exit(True);
         end


### PR DESCRIPTION
When the field has no value (null), the framework raises an exception to inform the wrong data type.
Just changing the type from ftCurrency to ftGUID to solve the problem.