### PR TITLE
Fix crash caused by null value set as a nested record.

### DIFF
--- a/sources/MVCFramework.Serializer.JsonDataObjects.pas
+++ b/sources/MVCFramework.Serializer.JsonDataObjects.pas
@@ -1803,6 +1803,9 @@ var
 
 begin
   lChildObject := nil;
+  if AJSONObject = nil then
+    Exit;
+    
   case AJSONObject[APropertyName].Typ of
     jdtNone:
       Exit;


### PR DESCRIPTION
Normal Example:
```
{
    "label": "test",
    "nested": {
        "inner": "inner text" 
    }
}
```

Problem Example:
```
{
    "label": "test",
    "nested": null
}
```