### PR TITLE
Fixes serialization of enumerations from dataset

### DIFF
--- a/sources/MVCFramework.Serializer.Commons.pas
+++ b/sources/MVCFramework.Serializer.Commons.pas
@@ -1157,7 +1157,15 @@ begin
         // general enumerations
     		else if (aRTTIField.FieldType.TypeKind = tkEnumeration) then
         begin
-          TValue(AField.AsInteger).ExtractRawData(PByte(Pointer(AObject)) + aRTTIField.Offset);
+          var Value: TValue;
+          case aRTTIField.FieldType.TypeSize of
+            SizeOf(Byte): Value := TValue.From<Byte>(AField.AsInteger);
+            SizeOf(Word): Value := TValue.From<Word>(AField.AsInteger);
+            SizeOf(Integer): Value := TValue.From<Integer>(AField.AsInteger);
+            else
+              raise EMVCException.CreateFmt('Unsupported enumeration type for field %s', [AField.FieldName]);
+          end;
+          Value.ExtractRawData(PByte(Pointer(AObject)) + aRTTIField.Offset);
         end
         // plain integers
         else


### PR DESCRIPTION
@danieleteti 

I found a problem serializing datasets for classes that contain enumerators.

By default, enumerators in Delphi can have 1, 2, or 4 bytes when stored in memory, depending on their values.

In the current implementation, the value is typecast to Integer, which has 4 bytes. If the enumerator has only 1 byte, the memory will be overwritten, causing values from other fields to be lost.