### PR TITLE
Update MVCFramework.SSEClient.pas

### DIFF
--- a/sources/MVCFramework.SSEClient.pas
+++ b/sources/MVCFramework.SSEClient.pas
@@ -134,13 +134,13 @@ begin
     SSEMessage.Text := ASSEMessage;
 
     if SSEMessage.IndexOfName('id')>-1 then
-      fLastEventId := SSEMessage.Values['id'].ToInteger;
+      fLastEventId := SSEMessage.Values['id'].Trim.ToInteger;
     if SSEMessage.IndexOfName('event')>-1 then
-      event := SSEMessage.Values['event'];
+      event := SSEMessage.Values['event'].Trim;
     if SSEMessage.IndexOfName('data')>-1 then
-      data := SSEMessage.Values['data'];
+      data := SSEMessage.Values['data'].Trim;
     if SSEMessage.IndexOfName('retry')>-1 then
-      fReconnectTimeout := StrToIntDef(SSEMessage.Values['retry'], DefaultReconnectTimeout);
+      fReconnectTimeout := StrToIntDef(SSEMessage.Values['retry'].Trim, DefaultReconnectTimeout);
 
     fOnSSEEvent(Self, fLastEventId, event, data);
   finally


### PR DESCRIPTION
Since the format of SSE contains spaces between command and value, we have to trim the value part. sample:
event: userconnect
data: {"username": "bobby", "time": "02:33:48"}