### PR TITLE
Improvements in serialization of TGUID types

### DIFF
--- a/sources/MVCFramework.Commons.pas
+++ b/sources/MVCFramework.Commons.pas
@@ -841,6 +841,7 @@ uses
   IdCoder3to4,
   System.NetEncoding,
   System.Character,
+  System.SysConst,
   MVCFramework.Serializer.JsonDataObjects,
   MVCFramework.Utils,
   System.RegularExpressions,
@@ -1645,25 +1646,28 @@ end;
 
 class function TMVCGuidHelper.StringToGUIDEx(const aGuidStr: string): TGUID;
 var
-  lGuidStr: string;
+  I: Integer;
+  LGuidStr: string;
 begin
-  case aGuidStr.Length of
-    32: { string uuid without braces and dashes: ae502abe430bb23a28782d18d6a6e465 }
-      begin
-        lGuidStr := Format('{%s-%s-%s-%s-%s}', [aGuidStr.Substring(0, 8), aGuidStr.Substring(8, 4),
-          aGuidStr.Substring(12, 4), aGuidStr.Substring(16, 4), aGuidStr.Substring(20, 12)]);
-      end;
-    36: { string uuid without braces: ae502abe-430b-b23a-2878-2d18d6a6e465 }
-      begin
-        lGuidStr := Format('{%s}', [aGuidStr])
-      end
-  else
-    begin
-      lGuidStr := aGuidStr;
-    end;
+  LGuidStr := '';
+  for I := 0 to Pred(aGuidStr.Length) do
+  begin
+    if CharInSet(aGuidStr.Chars[I], ['0' .. '9', 'a' .. 'f', 'A' .. 'F']) then
+      LGuidStr := LGuidStr + aGuidStr.Chars[I];
   end;
+  if LGuidStr.Length <> 32 then
+    raise EConvertError.CreateResFmt(@SInvalidGUID, [LGuidStr]);
 
-  Result := StringToGUID(lGuidStr);
+  LGuidStr := Format('{%s-%s-%s-%s-%s}',
+    [
+     LGuidStr.Substring(0, 8),
+     LGuidStr.Substring(8, 4),
+     LGuidStr.Substring(12, 4),
+     LGuidStr.Substring(16, 4),
+     LGuidStr.Substring(20, 12)
+    ]);
+
+  Result := StringToGUID(LGuidStr);
 end;
 
 function CamelCase(const Value: string; const MakeFirstUpperToo: Boolean): string;

--- a/sources/MVCFramework.Serializer.JsonDataObjects.CustomTypes.pas
+++ b/sources/MVCFramework.Serializer.JsonDataObjects.CustomTypes.pas
@@ -1,4 +1,4 @@
-// ***************************************************************************
+﻿// ***************************************************************************
 //
 // Delphi MVC Framework
 //
@@ -169,6 +169,7 @@ type
 implementation
 
 uses
+  System.SysConst,
   Data.DB,
   MVCFramework.DuckTyping,
   System.Generics.Collections,
@@ -360,12 +361,16 @@ procedure TMVCGUIDSerializer.SerializeAttribute(const AElementValue: TValue; con
   const ASerializerObject: TObject; const AAttributes: TArray<TCustomAttribute>);
 var
   lGuid: TGUID;
+  lGuidSerializationType: TMVCGuidSerializationType;
+  lGuidSerializationAttr: MVCGuidSerializationAttribute;
 begin
   lGuid := AElementValue.AsType<TGUID>;
-  if TMVCSerializerHelper.AttributeExists<MVCSerializeGuidWithoutBracesAttribute>(AAttributes) then
-    (ASerializerObject as TJDOJsonObject).S[APropertyName] := TMVCGuidHelper.GUIDToStringEx(lGuid)
-  else
-    (ASerializerObject as TJDOJsonObject).S[APropertyName] := lGuid.ToString;
+  lGuidSerializationType := TMVCGuidSerializationType.gstUseDefault;
+  if TMVCSerializerHelper.AttributeExists<MVCGuidSerializationAttribute>(AAttributes, lGuidSerializationAttr) then
+  begin
+    lGuidSerializationType := lGuidSerializationAttr.GuidSerializationType;
+  end;
+  (ASerializerObject as TJDOJsonObject).S[APropertyName] := TMVCSerializerHelper.ApplyGuidSerialization(lGuidSerializationType, lGuid);
 end;
 
 procedure TMVCGUIDSerializer.SerializeRoot(const AObject: TObject; out ASerializerObject: TObject;

--- a/sources/MVCFramework.pas
+++ b/sources/MVCFramework.pas
@@ -1317,6 +1317,7 @@ uses
   IdURI,
   IdStack,
   System.StrUtils,
+  System.SysConst,
   sqids,
   MVCFramework.SysControllers,
   MVCFramework.Serializer.JsonDataObjects,
@@ -1325,7 +1326,8 @@ uses
   MVCFramework.Rtti.Utils,
   MVCFramework.Serializer.HTML,
   MVCFramework.Serializer.Abstract,
-  MVCFramework.Utils, MVCFramework.Serializer.Text;
+  MVCFramework.Utils,
+  MVCFramework.Serializer.Text;
 
 var
   gIsShuttingDown: Boolean = False;

--- a/unittests/common/MVCFramework.Tests.Serializer.Entities.pas
+++ b/unittests/common/MVCFramework.Tests.Serializer.Entities.pas
@@ -233,6 +233,41 @@ type
     property NullableGuid2: NullableTGUID read FNullableGuid2 write FNullableGuid2;
   end;
 
+  TEntityCustomWithGuid2 = class(TEntityCustom)
+  private
+    FGuidValue: TGUID;
+    FGuidDefault: TGUID;
+    FGuidDigits: TGUID;
+    FGuidBraces: TGUID;
+    FGuidDashes: TGUID;
+    FNullableGuidDefault: NullableTGUID;
+    FNullableGuidDigits: NullableTGUID;
+    FNullableGuidBraces: NullableTGUID;
+    FNullableGuidDashes: NullableTGUID;
+    FNullableGuidValue: NullableTGUID;
+  public
+    property GuidValue: TGUID read FGuidValue write FGuidValue;
+    [MVCGuidSerialization(gstUseDefault)]
+    property GuidDefault: TGUID read FGuidDefault write FGuidDefault;
+    [MVCGuidSerialization(gstDigits)]
+    property GuidDigits: TGUID read FGuidDigits write FGuidDigits;
+    [MVCGuidSerialization(gstDashes)]
+    property GuidDashes: TGUID read FGuidDashes write FGuidDashes;
+    [MVCGuidSerialization(gstBraces)]
+    property GuidBraces: TGUID read FGuidBraces write FGuidBraces;
+
+    property NullableGuidValue: NullableTGUID read FNullableGuidValue write FNullableGuidValue;
+    [MVCGuidSerialization(gstUseDefault)]
+    property NullableGuidDefault: NullableTGUID read FNullableGuidDefault write FNullableGuidDefault;
+    [MVCGuidSerialization(gstDigits)]
+    property NullableGuidDigits: NullableTGUID read FNullableGuidDigits write FNullableGuidDigits;
+    [MVCGuidSerialization(gstDashes)]
+    property NullableGuidDashes: NullableTGUID read FNullableGuidDashes write FNullableGuidDashes;
+    [MVCGuidSerialization(gstBraces)]
+    property NullableGuidBraces: NullableTGUID read FNullableGuidBraces write FNullableGuidBraces;
+  end;
+
+
   TColorEnum = (RED, GREEN, BLUE);
   TMonthEnum = (meJanuary, meFebruary, meMarch, meApril);
   TMonths = set of TMonthEnum;

--- a/unittests/general/TestClient/Serializers.JsonDataObjectsTestU.pas
+++ b/unittests/general/TestClient/Serializers.JsonDataObjectsTestU.pas
@@ -124,6 +124,8 @@ type
     [Test]
     procedure TestSerializeDeserializeGuid;
     [Test]
+    procedure TestSerializeDeserializeGuidSerializtionType;
+    [Test]
     procedure TestSerializeDeserializeEntityWithInterface;
 
     [Test]
@@ -1843,6 +1845,8 @@ var
   LEntity: TEntityCustomWithGuid;
   LJson: string;
 begin
+  MVCNameCaseDefault := ncAsIs;
+
   LEntity := TEntityCustomWithGuid.Create;
   try
     LEntity.Id := 1;
@@ -1872,6 +1876,133 @@ begin
   finally
     LEntity.Free;
   end;
+end;
+
+procedure TMVCTestSerializerJsonDataObjects.TestSerializeDeserializeGuidSerializtionType;
+const
+  JSON =
+    '{' +
+    '"GuidValue":"{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}",' +
+    '"GuidDefault":"{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}",' +
+    '"GuidDigits":"d0e6449bae014e3d96b1d4a90f466a80",' +
+    '"GuidDashes":"d0e6449b-ae01-4e3d-96b1-d4a90f466a80",' +
+    '"GuidBraces":"{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}",' +
+    '"NullableGuidValue":"{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}",' +
+    '"NullableGuidDefault":"{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}",' +
+    '"NullableGuidDigits":"d0e6449bae014e3d96b1d4a90f466a80",' +
+    '"NullableGuidDashes":"d0e6449b-ae01-4e3d-96b1-d4a90f466a80",' +
+    '"NullableGuidBraces":"{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}",' +
+    '"Id":1,' + '"Code":2,' +
+    '"Name":"João Antônio"' + '}';
+
+const
+  JSON_CHANGED_GLOBAL_DEFAULT_TO_DASHES =
+    '{' +
+    '"GuidValue":"d0e6449b-ae01-4e3d-96b1-d4a90f466a80",' +
+    '"GuidDefault":"d0e6449b-ae01-4e3d-96b1-d4a90f466a80",' +
+    '"GuidDigits":"d0e6449bae014e3d96b1d4a90f466a80",' +
+    '"GuidDashes":"d0e6449b-ae01-4e3d-96b1-d4a90f466a80",' +
+    '"GuidBraces":"{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}",' +
+    '"NullableGuidValue":"d0e6449b-ae01-4e3d-96b1-d4a90f466a80",' +
+    '"NullableGuidDefault":"d0e6449b-ae01-4e3d-96b1-d4a90f466a80",' +
+    '"NullableGuidDigits":"d0e6449bae014e3d96b1d4a90f466a80",' +
+    '"NullableGuidDashes":"d0e6449b-ae01-4e3d-96b1-d4a90f466a80",' +
+    '"NullableGuidBraces":"{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}",' +
+    '"Id":1,' + '"Code":2,' +
+    '"Name":"João Antônio"' + '}';
+
+var
+  LEntity: TEntityCustomWithGuid2;
+  LJson: string;
+begin
+  MVCNameCaseDefault := ncAsIs;
+
+  LEntity := TEntityCustomWithGuid2.Create;
+  try
+    LEntity.Id := 1;
+    LEntity.Code := 2;
+    LEntity.Name := 'João Antônio';
+    LEntity.GuidValue := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.GuidDefault := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.GuidDigits := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.GuidDashes := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.GuidBraces := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.NullableGuidValue := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.NullableGuidDefault := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.NullableGuidDigits := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.NullableGuidDashes := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.NullableGuidBraces := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+
+    LJson := fSerializer.SerializeObject(LEntity);
+    Assert.AreEqual(JSON, LJson);
+  finally
+    LEntity.Free;
+  end;
+
+  LEntity := TEntityCustomWithGuid2.Create;
+  try
+    fSerializer.DeserializeObject(LJson, LEntity);
+    Assert.AreEqual(int64(1), LEntity.Id);
+    Assert.AreEqual(Integer(2), LEntity.Code);
+    Assert.AreEqual('João Antônio', LEntity.Name);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.GuidValue);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.GuidDefault);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.GuidDigits);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.GuidDashes);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.GuidBraces);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.NullableGuidValue.Value);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.NullableGuidDefault.Value);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.NullableGuidDigits.Value);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.NullableGuidDashes.Value);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.NullableGuidBraces.Value);
+  finally
+    LEntity.Free;
+  end;
+
+  MVCGuidSerializationTypeDefault := gstDashes;
+
+  LEntity := TEntityCustomWithGuid2.Create;
+  try
+    LEntity.Id := 1;
+    LEntity.Code := 2;
+    LEntity.Name := 'João Antônio';
+    LEntity.GuidValue := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.GuidDefault := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.GuidDigits := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.GuidDashes := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.GuidBraces := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.NullableGuidValue := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.NullableGuidDefault := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.NullableGuidDigits := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.NullableGuidDashes := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+    LEntity.NullableGuidBraces := StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}');
+
+    LJson := fSerializer.SerializeObject(LEntity);
+    Assert.AreEqual(JSON_CHANGED_GLOBAL_DEFAULT_TO_DASHES, LJson);
+  finally
+    LEntity.Free;
+  end;
+
+  LEntity := TEntityCustomWithGuid2.Create;
+  try
+    fSerializer.DeserializeObject(LJson, LEntity);
+    Assert.AreEqual(int64(1), LEntity.Id);
+    Assert.AreEqual(Integer(2), LEntity.Code);
+    Assert.AreEqual('João Antônio', LEntity.Name);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.GuidValue);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.GuidDefault);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.GuidDigits);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.GuidDashes);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.GuidBraces);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.NullableGuidValue.Value);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.NullableGuidDefault.Value);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.NullableGuidDigits.Value);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.NullableGuidDashes.Value);
+    Assert.AreEqual(StringToGUID('{D0E6449B-AE01-4E3D-96B1-D4A90F466A80}'), LEntity.NullableGuidBraces.Value);
+  finally
+    LEntity.Free;
+  end;
+  MVCGuidSerializationTypeDefault := gstBraces;
 end;
 
 procedure TMVCTestSerializerJsonDataObjects.TestSerializeDeserializeMultipleGenericEntity;


### PR DESCRIPTION
The `MVCGuidSerialization` attribute has been added to define the serialization format for TGUID types.

A global variable `MVCGuidSerializationTypeDefault` has also been added to allow you to set a global serialization type for Guids types.

The default serialization remains the same, in the Delphi Guid.ToString style.