### PR TITLE
fix(request): restore ISAPI-relative PathInfo (IIS routing 404 regression)

### DIFF
--- a/sources/MVCFramework.WebBroker.Request.pas
+++ b/sources/MVCFramework.WebBroker.Request.pas
@@ -443,14 +443,23 @@ function TMVCWebBrokerRequest.GetPathInfo: string;
 var
   LQueryPos: Integer;
 begin
-  // Apache (Web.HTTPD24Impl) splits the URI CGI-style — the first
-  // matching segment goes to ScriptName and the rest into PathInfo, and
-  // the split point is not always on a '/' boundary (colons, dots and
-  // other characters can confuse it). ScriptName+PathInfo is therefore
-  // not safe to concatenate.
-  // TWebRequest.URL maps to Apache's unparsed_uri (and to the full URL
-  // under the Indy bridge), so stripping the query string yields the
-  // same original path in every WebBroker host.
+  // ISAPI/IIS: PathInfo already holds the path relative to the extension
+  // (the .dll), which is exactly what the router expects - bare requests to
+  // the .dll yield '' and route to '/'. URL and ScriptName, in contrast,
+  // still carry the '/api/MyServerISAPI.dll' prefix and would make every
+  // route 404. ScriptName ending in '.dll' is the reliable "hosted as an
+  // ISAPI extension" signal, so there we keep the original PathInfo
+  // behaviour. (Apache fills ScriptName with a route segment without '.dll';
+  // the Indy bridge leaves it empty - both fall through to the URL path.)
+  if FWebRequest.ScriptName.ToLower.EndsWith('.dll') then
+    Exit(FWebRequest.PathInfo);
+  // Apache (Web.HTTPD24Impl) splits the URI CGI-style — the first matching
+  // segment goes to ScriptName and the rest into PathInfo, and the split
+  // point is not always on a '/' boundary (colons, dots and other characters
+  // can confuse it). ScriptName+PathInfo is therefore not safe to concatenate.
+  // TWebRequest.URL maps to Apache's unparsed_uri (and to the full URL under
+  // the Indy bridge), so stripping the query string yields the same original
+  // path in every non-ISAPI WebBroker host.
   Result := FWebRequest.URL;
   LQueryPos := Pos('?', Result);
   if LQueryPos > 0 then


### PR DESCRIPTION
## Summary

Routing is broken for every endpoint when the framework is hosted as an **ISAPI extension under IIS**: any request returns `{"message":"Resource not found"}`, including a bare request to the `.dll` that should hit the `/` route. The exact same server works correctly when hosted standalone (Indy bridge). This is a regression — ISAPI used to route fine.

## Reproduction

- Host a DMVC server as an ISAPI DLL under IIS (e.g. application `/api`, extension `MyServerISAPI.dll`, a controller mapped to `[MVCPath('/')]`).
- `GET http://localhost/api/MyServerISAPI.dll` → **404** `{"message":"Resource not found"}`.
- The same controllers hosted via `TIdHTTPWebBrokerBridge` (standalone) → **200**.

## Root cause

`TMVCWebBrokerRequest.GetPathInfo` (in `MVCFramework.WebBroker.Request.pas`) originally returned `FWebRequest.PathInfo`. Under ISAPI/IIS that value is already the path **relative to the extension** — exactly what the router expects (a bare request to the `.dll` yields `''`, which the router normalizes to `/`).

Two later changes replaced that source:

- `13fb2c85` (*fix PathInfo for Apache 2.4 module*) → `FWebRequest.ScriptName + FWebRequest.PathInfo`
- `9247d4f8` (*URL reconstruction via unparsed_uri*) → `FWebRequest.URL`

Both are correct for Apache and the Indy bridge, but under ISAPI they reintroduce the `/api/MyServerISAPI.dll` script-name prefix into the routing path. The router then tries to match `/api/MyServerISAPI.dll` as a route, finds nothing, and answers *Resource not found*. (`InternalExecuteAction`'s `#826` Raw/Decoded fallback does not help, because `GetRawPathInfo` delegates to `GetPathInfo`, so both sides carry the prefix.)

## Fix

`GetPathInfo` now early-returns the original `FWebRequest.PathInfo` **only when the host is an ISAPI extension**, detected via `ScriptName` ending in `.dll` (the web server's `SCRIPT_NAME`). For every other host the method is unchanged (URL-based), so the Apache and Indy paths the reconstruction was introduced for are untouched.

```pascal
if FWebRequest.ScriptName.ToLower.EndsWith('.dll') then
  Exit(FWebRequest.PathInfo);
// ...unchanged URL-based logic for Apache / Indy bridge...
```

## Behaviour per host

| Host | `ScriptName` | Path used for routing | Result |
|------|--------------|-----------------------|--------|
| ISAPI / IIS | `/api/MyServerISAPI.dll` (ends `.dll`) | `FWebRequest.PathInfo` (relative to extension) | restored ✅ |
| Apache 2.4 module | `/api` (route segment, no `.dll`) | `FWebRequest.URL` (unchanged) | unaffected |
| Standalone (Indy bridge) | `''` (empty) | `FWebRequest.URL` (unchanged) | unaffected |

Because the early return is gated on the script itself being a `.dll`, routes that legitimately contain `.dll` in their path are never affected on non-ISAPI hosts.

## Notes

- Single-file change, no public API change.
- Verified against a live IIS ISAPI deployment (404 → 200 on `/` and sub-routes) and against the standalone Indy host (no change in behaviour).
