### PR TITLE
WebSocket: expose HTTP handshake headers on TWebSocketClient (X-Forwarded-For, Origin, auth behind proxy)

### DIFF
--- a/sources/MVCFramework.WebSocket.Server.pas
+++ b/sources/MVCFramework.WebSocket.Server.pas
@@ -86,9 +86,10 @@ type
     FOwnsData: Boolean;
     FPeriodicInterval: Integer;
     FServer: TMVCWebSocketServer;
+    FHandshakeHeaders: TStrings;   // owned; HTTP handshake request headers (holds a TStringList)
     function GetConnectedUsersCount: Integer;
   public
-    constructor Create(AContext: TIdContext; const AClientId: string; AServer: TMVCWebSocketServer; AOwnsData: Boolean = True);
+    constructor Create(AContext: TIdContext; const AClientId: string; AServer: TMVCWebSocketServer; AOwnsData: Boolean = True; AHandshakeHeaders: TStringList = nil);
     destructor Destroy; override;
 
     /// <summary>
@@ -146,6 +147,11 @@ type
 
     property Context: TIdContext read FContext;
     property ClientId: string read FClientId;
+    /// <summary>HTTP request headers from the WebSocket upgrade handshake (read-only).
+    /// Useful for X-Forwarded-For (real client IP behind a proxy), Origin, cookies, auth.</summary>
+    property HandshakeHeaders: TStrings read FHandshakeHeaders;
+    /// <summary>Real client IP: first X-Forwarded-For entry if present, else ClientId (peer IP).</summary>
+    function RealClientIP: string;
 
     /// <summary>
     /// Username for this client (can be set in OnClientConnect)
@@ -198,7 +204,7 @@ type
     FOnPeriodicMessage: TWebSocketPeriodicMessageEvent;
     FPeriodicMessageInterval: Integer;
     procedure OnExecuteEvent(AContext: TIdContext);
-    function PerformHandshake(AContext: TIdContext; out AClientId: string): Boolean;
+    function PerformHandshake(AContext: TIdContext; out AClientId: string; out AHeaders: TStringList): Boolean;
     procedure ProcessFrames(AClient: TWebSocketClient);
     function GetClientCount: Integer;
   protected
@@ -283,9 +289,13 @@ uses
 
 { TWebSocketClient }
 
-constructor TWebSocketClient.Create(AContext: TIdContext; const AClientId: string; AServer: TMVCWebSocketServer; AOwnsData: Boolean);
+constructor TWebSocketClient.Create(AContext: TIdContext; const AClientId: string; AServer: TMVCWebSocketServer; AOwnsData: Boolean; AHandshakeHeaders: TStringList);
 begin
   inherited Create;
+  if AHandshakeHeaders <> nil then
+    FHandshakeHeaders := AHandshakeHeaders   // take ownership
+  else
+    FHandshakeHeaders := TStringList.Create;
   FContext := AContext;
   FClientId := AClientId;
   FUsername := AClientId; // Default username is ClientId (IP address)
@@ -298,9 +308,32 @@ end;
 
 destructor TWebSocketClient.Destroy;
 begin
+  FHandshakeHeaders.Free;
   if FOwnsData and Assigned(FData) then
     FData.Free;
   inherited;
+end;
+
+function TWebSocketClient.RealClientIP: string;
+var
+  LLine, LXFF: string;
+  LP: Integer;
+begin
+  LXFF := '';
+  if FHandshakeHeaders <> nil then
+    for LLine in FHandshakeHeaders do
+      if LLine.StartsWith('X-Forwarded-For:', True) then
+      begin
+        LXFF := LLine.Substring(Length('X-Forwarded-For:')).Trim;
+        LP := Pos(',', LXFF);
+        if LP > 0 then
+          LXFF := Trim(Copy(LXFF, 1, LP - 1));
+        Break;
+      end;
+  if LXFF <> '' then
+    Result := LXFF
+  else
+    Result := FClientId;
 end;
 
 procedure TWebSocketClient.SendText(const AMessage: string);
@@ -499,7 +532,7 @@ begin
   end;
 end;
 
-function TMVCWebSocketServer.PerformHandshake(AContext: TIdContext; out AClientId: string): Boolean;
+function TMVCWebSocketServer.PerformHandshake(AContext: TIdContext; out AClientId: string; out AHeaders: TStringList): Boolean;
 var
   LRequestLine, LLine: string;
   LHeaders: TStringList;
@@ -507,6 +540,7 @@ var
   LIOHandler: TIdIOHandler;
 begin
   Result := False;
+  AHeaders := nil;
   LIOHandler := AContext.Connection.IOHandler;
   LHeaders := TStringList.Create;
   try
@@ -574,9 +608,11 @@ begin
     // CRITICAL: Clear buffer after handshake
     LIOHandler.InputBuffer.Clear;
 
+    AHeaders := LHeaders;   // transfer ownership to caller (the client will own it)
+    LHeaders := nil;
     Result := True;
   finally
-    LHeaders.Free;
+    LHeaders.Free;          // nil-safe: frees only on failure paths
   end;
 end;
 
@@ -701,16 +737,17 @@ procedure TMVCWebSocketServer.OnExecuteEvent(AContext: TIdContext);
 var
   LClientId: string;
   LClient: TWebSocketClient;
+  LHandshakeHeaders: TStringList;
 begin
   LClient := nil;
   try
     // Perform WebSocket handshake
-    if PerformHandshake(AContext, LClientId) then
+    if PerformHandshake(AContext, LClientId, LHandshakeHeaders) then
     begin
       DoLog(Format('WebSocket handshake successful for %s', [LClientId]));
 
       // Create client object
-      LClient := TWebSocketClient.Create(AContext, LClientId, Self);
+      LClient := TWebSocketClient.Create(AContext, LClientId, Self, True, LHandshakeHeaders);
 
       // Add to clients list
       FClientsLock.Enter;


### PR DESCRIPTION
## Problem

`TMVCWebSocketServer.PerformHandshake` reads the WebSocket upgrade request headers into a local `TStringList` and frees them. After the upgrade the application layer cannot access the original HTTP request, so it is impossible to:

- obtain the real client IP behind a reverse proxy (`X-Forwarded-For`);
- inspect `Origin` / cookies / `Authorization` for a WebSocket connection.

`TWebSocketClient` today exposes only `ClientId` (peer IP) and `Context`.

## Change

- Retain the handshake headers and expose them read-only on `TWebSocketClient` via a new `HandshakeHeaders: TStrings` property.
- Add a `RealClientIP: string` convenience that returns the first `X-Forwarded-For` entry if present, otherwise `ClientId`.
- `PerformHandshake` transfers ownership of the header list to the client; the client frees it on destroy.

## Compatibility

Fully backward compatible:

- `ClientId` behaviour is unchanged (still peer IP / `Sec-WebSocket-Protocol`);
- the new constructor parameter is optional (`AHandshakeHeaders: TStringList = nil`);
- no behaviour change when there is no proxy / no `X-Forwarded-For`.

## Testing

Verified against `3.5.0-silicon-rc2`: a WS handshake with `X-Forwarded-For: 203.0.113.7, 10.0.0.1` yields `RealClientIP = 203.0.113.7`; without the header, `RealClientIP = ClientId` (peer IP). Existing WebSocket connect/subscribe/event flow unaffected.
